### PR TITLE
Added eslint plugin to disallow using "import" keyword in debug comments

### DIFF
--- a/packages/eslint-config-ckeditor5/.eslintrc.js
+++ b/packages/eslint-config-ckeditor5/.eslintrc.js
@@ -302,9 +302,14 @@ module.exports = {
 			'error',
 			'after'
 		],
+
+		// CKEditor 5 rules.
 		'ckeditor5-rules/no-relative-imports': 'error',
 		'ckeditor5-rules/ckeditor-error-message': 'error',
 		'ckeditor5-rules/no-cross-package-imports': 'error',
+		'ckeditor5-rules/use-require-for-debug-mode-imports': 'error',
+
+		// Rules for tests.
 		'mocha/handle-done-callback': 'error',
 		'mocha/no-async-describe': 'error',
 		'mocha/no-exclusive-tests': 'error',

--- a/packages/eslint-plugin-ckeditor5-rules/lib/index.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/index.js
@@ -11,6 +11,7 @@ module.exports = {
 		'ckeditor-error-message': require( './rules/ckeditor-error-message' ),
 		'ckeditor-imports': require( './rules/ckeditor-imports' ),
 		'no-cross-package-imports': require( './rules/no-cross-package-imports' ),
-		'license-header': require( './rules/license-header' )
+		'license-header': require( './rules/license-header' ),
+		'use-require-for-debug-mode-imports': require( './rules/use-require-for-debug-mode-imports' )
 	}
 };

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/use-require-for-debug-mode-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/use-require-for-debug-mode-imports.js
@@ -5,12 +5,12 @@
 
 'use strict';
 
-const DEFAULT_ALIAS_IMPORT = /import { default as (.*) } from ([^;]*);?;?/g;
-const NAMED_ALIAS_IMPORT = /import { (.*) as (.*) } from ([^;]*);?/g;
-const NAMED_IMPORT = /import { (.*) } from ([^;]*);?/g;
-const NAMESPACE_ALIAS_IMPORT = /import .* as (.*) from ([^;]*);?/g;
-const DEFAULT_IMPORT = /import (.*) from ([^;]*);?/g;
-const SIDE_EFFECT_IMPORT = /import ([^;]*);?/g;
+const DEFAULT_ALIAS_IMPORT = /import { default as (.*) } from ([^;]*);?;?/;
+const NAMED_ALIAS_IMPORT = /import { (.*) as (.*) } from ([^;]*);?/;
+const NAMED_IMPORT = /import { (.*) } from ([^;]*);?/;
+const NAMESPACE_ALIAS_IMPORT = /import .* as (.*) from ([^;]*);?/;
+const DEFAULT_IMPORT = /import (.*) from ([^;]*);?/;
+const SIDE_EFFECT_IMPORT = /import ([^;]*);?/;
 
 const DESTRUCTURED_ALIAS_REPLACE = 'const { $1: $2 } = require( $3 );';
 const DESTRUCTURED_REPLACE = 'const { $1 } = require( $2 );';
@@ -47,7 +47,7 @@ module.exports = {
 						messageId: 'usingImportNotAllowed',
 						fix( fixer ) {
 							const newCommentValue = getNewComment( comment.value );
-							const newComment = addCommentCharacters( comment.type, newCommentValue );
+							const newComment = '//' + newCommentValue;
 
 							return fixer.replaceText( comment, newComment );
 						}
@@ -63,7 +63,7 @@ module.exports = {
  * @returns {Boolean}
  */
 function debugCommentDoesNotContainImport( str = '' ) {
-	return !/@if CK_DEBUG.*\s*\/\/\s*import/.test( str );
+	return !/@if CK_DEBUG.*\s*\/\/\s*import/g.test( str );
 }
 
 /**
@@ -93,16 +93,3 @@ function getNewComment( value ) {
 
 	return value.replace( SIDE_EFFECT_IMPORT, SIDE_EFFECT_REPLACE );
 }
-
-/**
- * @param {String} type
- * @param {String} value
- * @returns {Boolean}
- */
-function addCommentCharacters( type, value ) {
-	const commentPrefix = type === 'Line' ? '//' : '/*';
-	const commentSuffix = type === 'Line' ? '' : '*/';
-
-	return commentPrefix + value + commentSuffix;
-}
-

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/use-require-for-debug-mode-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/use-require-for-debug-mode-imports.js
@@ -5,12 +5,12 @@
 
 'use strict';
 
-const DEFAULT_ALIAS_IMPORT = /import { default as (.*) } from (.*)?;/g;
-const NAMED_ALIAS_IMPORT = /import { (.*) as (.*) } from (.*)?;/g;
-const NAMED_IMPORT = /import { (.*) } from (.*)?;/g;
-const NAMESPACE_ALIAS_IMPORT = /import .* as (.*) from (.*)?;/g;
-const DEFAULT_IMPORT = /import (.*) from (.*)?;/g;
-const SIDE_EFFECT_IMPORT = /import (.*)?;/g;
+const DEFAULT_ALIAS_IMPORT = /import { default as (.*) } from ([^;]*);?;?/g;
+const NAMED_ALIAS_IMPORT = /import { (.*) as (.*) } from ([^;]*);?/g;
+const NAMED_IMPORT = /import { (.*) } from ([^;]*);?/g;
+const NAMESPACE_ALIAS_IMPORT = /import .* as (.*) from ([^;]*);?/g;
+const DEFAULT_IMPORT = /import (.*) from ([^;]*);?/g;
+const SIDE_EFFECT_IMPORT = /import ([^;]*);?/g;
 
 const DESTRUCTURED_ALIAS_REPLACE = 'const { $1: $2 } = require( $3 );';
 const DESTRUCTURED_REPLACE = 'const { $1 } = require( $2 );';

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/use-require-for-debug-mode-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/use-require-for-debug-mode-imports.js
@@ -1,0 +1,56 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+module.exports = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Disallow using import for functions used in debug mode.',
+			category: 'CKEditor5'
+		},
+		fixable: 'code',
+		messages: {
+			'usingImportNotAllowed': 'Using import with "@if CK_DEBUG" keyword is not allowed. Please Use require().'
+		},
+		schema: []
+	},
+	create( context ) {
+		return {
+			Program() {
+				const source = context.getSourceCode();
+				const comments = source.getAllComments();
+
+				for ( const comment of comments ) {
+					if ( debugCommentDoesNotContainImport( comment.value ) ) {
+						continue;
+					}
+
+					context.report( {
+						node: comment,
+						messageId: 'usingImportNotAllowed',
+						fix( fixer ) {
+							const commentPrefix = comment.type === 'Line' ? '//' : '/*';
+							const commentSuffix = comment.type === 'Line' ? '' : '*/';
+							const regex = /import (.*) from (.*)?;/;
+							const replaceVal = 'const $1 = require($2);';
+							const newCommentText = commentPrefix + comment.value.replace( regex, replaceVal ) + commentSuffix;
+							return fixer.replaceText( comment, newCommentText );
+						}
+					} );
+				}
+			}
+		};
+	}
+};
+
+/**
+ * @param {String} [str='']
+ * @return {Boolean}
+ */
+function debugCommentDoesNotContainImport( str = '' ) {
+	return !/@if CK_DEBUG \/\/ import .* from .*/.test( str );
+}

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/use-require-for-debug-mode-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/use-require-for-debug-mode-imports.js
@@ -5,12 +5,12 @@
 
 'use strict';
 
-const DEFAULT_ALIAS_IMPORT = /import { default as (.*) } from (.*)?;/;
-const NAMED_ALIAS_IMPORT = /import { (.*) as (.*) } from (.*)?;/;
-const NAMED_IMPORT = /import { (.*) } from (.*)?;/;
-const NAMESPACE_ALIAS_IMPORT = /import .* as (.*) from (.*)?;/;
-const DEFAULT_IMPORT = /import (.*) from (.*)?;/;
-const SIDE_EFFECT_IMPORT = /import (.*)?;/;
+const DEFAULT_ALIAS_IMPORT = /import { default as (.*) } from (.*)?;/g;
+const NAMED_ALIAS_IMPORT = /import { (.*) as (.*) } from (.*)?;/g;
+const NAMED_IMPORT = /import { (.*) } from (.*)?;/g;
+const NAMESPACE_ALIAS_IMPORT = /import .* as (.*) from (.*)?;/g;
+const DEFAULT_IMPORT = /import (.*) from (.*)?;/g;
+const SIDE_EFFECT_IMPORT = /import (.*)?;/g;
 
 const DESTRUCTURED_ALIAS_REPLACE = 'const { $1: $2 } = require( $3 );';
 const DESTRUCTURED_REPLACE = 'const { $1 } = require( $2 );';
@@ -63,7 +63,7 @@ module.exports = {
  * @returns {Boolean}
  */
 function debugCommentDoesNotContainImport( str = '' ) {
-	return !/@if CK_DEBUG.* \/\/ import/.test( str );
+	return !/@if CK_DEBUG.*\s*\/\/\s*import/.test( str );
 }
 
 /**

--- a/packages/eslint-plugin-ckeditor5-rules/tests/use-require-for-debug-mode-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/use-require-for-debug-mode-imports.js
@@ -1,0 +1,51 @@
+/**
+ * @license Copyright (c) 2003-2022, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const RuleTester = require( 'eslint' ).RuleTester;
+
+const ruleTester = new RuleTester();
+const usingImportNotAllowed = { message: 'Using import with "@if CK_DEBUG" keyword is not allowed. Please Use require().' };
+
+ruleTester.run(
+	'eslint-plugin-ckeditor5-rules/use-require-for-debug-mode-imports',
+	require( '../lib/rules/use-require-for-debug-mode-imports' ),
+	{
+		invalid: [
+			{
+				code: '// @if CK_DEBUG // import TestPackage from \'test-package\';',
+				output: '// @if CK_DEBUG // const TestPackage = require(\'test-package\');',
+				errors: [ usingImportNotAllowed ]
+			},
+			{
+				code: '// @if CK_DEBUG // import { testFunction } from \'test-package\';',
+				output: '// @if CK_DEBUG // const { testFunction } = require(\'test-package\');',
+				errors: [ usingImportNotAllowed ]
+			},
+			{
+				code: '/**\n' +
+				'* @if CK_DEBUG // import TestPackage from \'test-package\';\n' +
+				'*/',
+				output: '/**\n' +
+				'* @if CK_DEBUG // const TestPackage = require(\'test-package\');\n' +
+				'*/',
+				errors: [ usingImportNotAllowed ] }
+		],
+		valid: [
+			{
+				code: '// @if CK_DEBUG // const TestPackage = require(\'test-package\');'
+			},
+			{
+				code: '// @if CK_DEBUG // const { testFunction } = require(\'test-package\');'
+			},
+			{
+				code: '/**\n' +
+				'* @if CK_DEBUG // const TestPackage = require(\'test-package\');\n' +
+				'*/'
+			}
+		]
+	}
+);

--- a/packages/eslint-plugin-ckeditor5-rules/tests/use-require-for-debug-mode-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/use-require-for-debug-mode-imports.js
@@ -58,6 +58,17 @@ ruleTester.run(
 				'* @if CK_DEBUG // const defaultExport = require( \'module-name\' ).default;\n' +
 				'*/',
 				errors: [ usingImportNotAllowed ]
+			},
+			{
+				code: '/**\n' +
+				'* @if CK_DEBUG // import defaultExport from \'module-name\';\n' +
+				'* @if CK_DEBUG_FOO // import otherDefaultExport from \'other-module-name\';\n' +
+				'*/',
+				output: '/**\n' +
+				'* @if CK_DEBUG // const defaultExport = require( \'module-name\' ).default;\n' +
+				'* @if CK_DEBUG_FOO // const otherDefaultExport = require( \'other-module-name\' ).default;\n' +
+				'*/',
+				errors: [ usingImportNotAllowed ]
 			}
 		],
 		valid: [
@@ -86,8 +97,20 @@ ruleTester.run(
 				code: '// @if CK_DEBUG // require( \'module-name\' );'
 			},
 			{
+				code: '// @if CK_DEBUG 	// require( \'module-name\' );'
+			},
+			{
+				code: '// @if CK_DEBUG //	require( \'module-name\' );'
+			},
+			{
 				code: '/**\n' +
 				'* @if CK_DEBUG // const testModule = require( \'module-name\' );\n' +
+				'*/'
+			},
+			{
+				code: '/**\n' +
+				'* @if CK_DEBUG // const testModule = require( \'module-name\' );\n' +
+				'* @if CK_DEBUG_FOO // const testOtherModule = require( \'other-module-name\' );\n' +
 				'*/'
 			}
 		]

--- a/packages/eslint-plugin-ckeditor5-rules/tests/use-require-for-debug-mode-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/use-require-for-debug-mode-imports.js
@@ -31,6 +31,11 @@ ruleTester.run(
 				errors: [ usingImportNotAllowed ]
 			},
 			{
+				code: '// @if CK_DEBUG // import { testFunctionOne, testFunctionTwo } from \'module-name\';',
+				output: '// @if CK_DEBUG // const { testFunctionOne, testFunctionTwo } = require( \'module-name\' );',
+				errors: [ usingImportNotAllowed ]
+			},
+			{
 				code: '// @if CK_DEBUG // import { default as alias } from \'module-name\';',
 				output: '// @if CK_DEBUG // const alias = require( \'module-name\' ).default;',
 				errors: [ usingImportNotAllowed ]
@@ -46,16 +51,6 @@ ruleTester.run(
 				errors: [ usingImportNotAllowed ]
 			},
 			{
-				code: '// @if CK_DEBUG_MINIMAP // import { testFunction } from \'module-name\';',
-				output: '// @if CK_DEBUG_MINIMAP // const { testFunction } = require( \'module-name\' );',
-				errors: [ usingImportNotAllowed ]
-			},
-			{
-				code: '// @if CK_DEBUG_MINIMAP // import { testFunctionOne, testFunctionTwo } from \'module-name\';',
-				output: '// @if CK_DEBUG_MINIMAP // const { testFunctionOne, testFunctionTwo } = require( \'module-name\' );',
-				errors: [ usingImportNotAllowed ]
-			},
-			{
 				code: '/**\n' +
 				'* @if CK_DEBUG // import defaultExport from \'module-name\';\n' +
 				'*/',
@@ -68,6 +63,12 @@ ruleTester.run(
 		valid: [
 			{
 				code: '// @if CK_DEBUG // const testModule = require( \'module-name\' );'
+			},
+			{
+				code: '// @if CK_DEBUG_MINIMAP // const testModule = require( \'module-name\' );'
+			},
+			{
+				code: '// @if CK_DEBUG_ENGINE // const testModule = require( \'module-name\' );'
 			},
 			{
 				code: '// @if CK_DEBUG // const defaultExport = require( \'module-name\' ).default;'
@@ -87,16 +88,6 @@ ruleTester.run(
 			{
 				code: '/**\n' +
 				'* @if CK_DEBUG // const testModule = require( \'module-name\' );\n' +
-				'*/'
-			},
-			{
-				code: '/**\n' +
-				'* @if CK_DEBUG_MINIMAP // const testModule = require( \'module-name\' );\n' +
-				'*/'
-			},
-			{
-				code: '/**\n' +
-				'* @if CK_DEBUG_ENGINE // const testModule = require( \'module-name\' );\n' +
 				'*/'
 			}
 		]

--- a/packages/eslint-plugin-ckeditor5-rules/tests/use-require-for-debug-mode-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/use-require-for-debug-mode-imports.js
@@ -8,7 +8,7 @@
 const RuleTester = require( 'eslint' ).RuleTester;
 
 const ruleTester = new RuleTester();
-const usingImportNotAllowed = { message: 'Using import with "@if CK_DEBUG" keyword is not allowed. Please Use require().' };
+const usingImportNotAllowed = { message: 'Using import with `@if CK_DEBUG_*` keyword is not allowed. Use `require()` instead.' };
 
 ruleTester.run(
 	'eslint-plugin-ckeditor5-rules/use-require-for-debug-mode-imports',
@@ -16,34 +16,87 @@ ruleTester.run(
 	{
 		invalid: [
 			{
-				code: '// @if CK_DEBUG // import TestPackage from \'test-package\';',
-				output: '// @if CK_DEBUG // const TestPackage = require(\'test-package\');',
+				code: '// @if CK_DEBUG // import defaultExport from \'module-name\';',
+				output: '// @if CK_DEBUG // const defaultExport = require( \'module-name\' ).default;',
 				errors: [ usingImportNotAllowed ]
 			},
 			{
-				code: '// @if CK_DEBUG // import { testFunction } from \'test-package\';',
-				output: '// @if CK_DEBUG // const { testFunction } = require(\'test-package\');',
+				code: '// @if CK_DEBUG // import * as name from \'module-name\';',
+				output: '// @if CK_DEBUG // const name = require( \'module-name\' );',
+				errors: [ usingImportNotAllowed ]
+			},
+			{
+				code: '// @if CK_DEBUG // import { testFunction } from \'module-name\';',
+				output: '// @if CK_DEBUG // const { testFunction } = require( \'module-name\' );',
+				errors: [ usingImportNotAllowed ]
+			},
+			{
+				code: '// @if CK_DEBUG // import { default as alias } from \'module-name\';',
+				output: '// @if CK_DEBUG // const alias = require( \'module-name\' ).default;',
+				errors: [ usingImportNotAllowed ]
+			},
+			{
+				code: '// @if CK_DEBUG // import { export1 as alias1 } from \'module-name\';',
+				output: '// @if CK_DEBUG // const { export1: alias1 } = require( \'module-name\' );',
+				errors: [ usingImportNotAllowed ]
+			},
+			{
+				code: '// @if CK_DEBUG // import \'module-name\';',
+				output: '// @if CK_DEBUG // require( \'module-name\' );',
+				errors: [ usingImportNotAllowed ]
+			},
+			{
+				code: '// @if CK_DEBUG_MINIMAP // import { testFunction } from \'module-name\';',
+				output: '// @if CK_DEBUG_MINIMAP // const { testFunction } = require( \'module-name\' );',
+				errors: [ usingImportNotAllowed ]
+			},
+			{
+				code: '// @if CK_DEBUG_MINIMAP // import { testFunctionOne, testFunctionTwo } from \'module-name\';',
+				output: '// @if CK_DEBUG_MINIMAP // const { testFunctionOne, testFunctionTwo } = require( \'module-name\' );',
 				errors: [ usingImportNotAllowed ]
 			},
 			{
 				code: '/**\n' +
-				'* @if CK_DEBUG // import TestPackage from \'test-package\';\n' +
+				'* @if CK_DEBUG // import defaultExport from \'module-name\';\n' +
 				'*/',
 				output: '/**\n' +
-				'* @if CK_DEBUG // const TestPackage = require(\'test-package\');\n' +
+				'* @if CK_DEBUG // const defaultExport = require( \'module-name\' ).default;\n' +
 				'*/',
-				errors: [ usingImportNotAllowed ] }
+				errors: [ usingImportNotAllowed ]
+			}
 		],
 		valid: [
 			{
-				code: '// @if CK_DEBUG // const TestPackage = require(\'test-package\');'
+				code: '// @if CK_DEBUG // const testModule = require( \'module-name\' );'
 			},
 			{
-				code: '// @if CK_DEBUG // const { testFunction } = require(\'test-package\');'
+				code: '// @if CK_DEBUG // const defaultExport = require( \'module-name\' ).default;'
+			},
+			{
+				code: '// @if CK_DEBUG // const { testFunction } = require( \'module-name\' );'
+			},
+			{
+				code: '// @if CK_DEBUG // const alias = require( \'module-name\' ).default;'
+			},
+			{
+				code: '// @if CK_DEBUG // const { export1: alias1 } = require( \'module-name\' );'
+			},
+			{
+				code: '// @if CK_DEBUG // require( \'module-name\' );'
 			},
 			{
 				code: '/**\n' +
-				'* @if CK_DEBUG // const TestPackage = require(\'test-package\');\n' +
+				'* @if CK_DEBUG // const testModule = require( \'module-name\' );\n' +
+				'*/'
+			},
+			{
+				code: '/**\n' +
+				'* @if CK_DEBUG_MINIMAP // const testModule = require( \'module-name\' );\n' +
+				'*/'
+			},
+			{
+				code: '/**\n' +
+				'* @if CK_DEBUG_ENGINE // const testModule = require( \'module-name\' );\n' +
 				'*/'
 			}
 		]

--- a/packages/eslint-plugin-ckeditor5-rules/tests/use-require-for-debug-mode-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/use-require-for-debug-mode-imports.js
@@ -54,26 +54,6 @@ ruleTester.run(
 				code: '// @if CK_DEBUG // import \'module-name-semicolon-missing\'',
 				output: '// @if CK_DEBUG // require( \'module-name-semicolon-missing\' );',
 				errors: [ usingImportNotAllowed ]
-			},
-			{
-				code: '/**\n' +
-				'* @if CK_DEBUG // import defaultExport from \'module-name\';\n' +
-				'*/',
-				output: '/**\n' +
-				'* @if CK_DEBUG // const defaultExport = require( \'module-name\' ).default;\n' +
-				'*/',
-				errors: [ usingImportNotAllowed ]
-			},
-			{
-				code: '/**\n' +
-				'* @if CK_DEBUG // import defaultExport from \'module-name\';\n' +
-				'* @if CK_DEBUG_FOO // import otherDefaultExport from \'other-module-name\';\n' +
-				'*/',
-				output: '/**\n' +
-				'* @if CK_DEBUG // const defaultExport = require( \'module-name\' ).default;\n' +
-				'* @if CK_DEBUG_FOO // const otherDefaultExport = require( \'other-module-name\' ).default;\n' +
-				'*/',
-				errors: [ usingImportNotAllowed ]
 			}
 		],
 		valid: [
@@ -106,17 +86,6 @@ ruleTester.run(
 			},
 			{
 				code: '// @if CK_DEBUG //	require( \'module-name\' );'
-			},
-			{
-				code: '/**\n' +
-				'* @if CK_DEBUG // const testModule = require( \'module-name\' );\n' +
-				'*/'
-			},
-			{
-				code: '/**\n' +
-				'* @if CK_DEBUG // const testModule = require( \'module-name\' );\n' +
-				'* @if CK_DEBUG_FOO // const testOtherModule = require( \'other-module-name\' );\n' +
-				'*/'
 			}
 		]
 	}

--- a/packages/eslint-plugin-ckeditor5-rules/tests/use-require-for-debug-mode-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/use-require-for-debug-mode-imports.js
@@ -51,6 +51,11 @@ ruleTester.run(
 				errors: [ usingImportNotAllowed ]
 			},
 			{
+				code: '// @if CK_DEBUG // import \'module-name-semicolon-missing\'',
+				output: '// @if CK_DEBUG // require( \'module-name-semicolon-missing\' );',
+				errors: [ usingImportNotAllowed ]
+			},
+			{
 				code: '/**\n' +
 				'* @if CK_DEBUG // import defaultExport from \'module-name\';\n' +
 				'*/',


### PR DESCRIPTION
Internal (eslint-plugin-ckeditor5-rules): Added eslint plugin to disallow using the "import" keyword in debug comments. Closes ckeditor/ckeditor5#12479.