### PR TITLE
Disable new-cap

### DIFF
--- a/packages/eslint-config-ckeditor5/.eslintrc.js
+++ b/packages/eslint-config-ckeditor5/.eslintrc.js
@@ -180,7 +180,7 @@ module.exports = {
 				max: 1
 			}
 		],
-		'new-cap': 'error',
+		'new-cap': 'off',
 		'new-parens': 'error',
 		'no-array-constructor': 'error',
 		'no-multiple-empty-lines': [


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Disables `new-cap`.

---

### Additional information

Because of the new [mixin style](https://github.com/cksource/ckeditor5-internal/blob/master/adr/0011-mixin-style.md), having this rule is super-annoying. I.e. `class Xyz extends ObservableMixin() { ... }` requires suspending it every time.
