### PR TITLE
Use `ckeditor5-dev-ci-notify-travis-status` script to send failure notifications on slack

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 **/node_modules/**
 **/coverage/**
 yarn.lock
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,13 @@ cache:
 cache:
   - node_modules
 before_install:
+  - export START_TIME=$( date +%s )
   - npm i -g yarn
 install:
   - yarn install
 script:
   - yarn run test
   - yarn run lint
+after_script:
+  - export END_TIME=$( date +%s )
+  - ckeditor5-dev-ci-notify-travis-status

--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "type": "git",
     "url": "https://github.com/ckeditor/ckeditor5-linters-config.git"
   },
+  "dependencies": {
+    "@ckeditor/ckeditor5-dev-ci": "^32.0.1"
+  },
   "devDependencies": {
     "@ckeditor/ckeditor5-dev-env": "^31.1.5",
     "eslint": "^7.0.0",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Use `ckeditor5-dev-ci-notify-travis-status` script to send failure notifications on slack.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
