### PR TITLE
Other (eslint-config-ckeditor5): Allow 'requires' methods not to specify return type.

### DIFF
--- a/packages/eslint-config-ckeditor5/.eslintrc.js
+++ b/packages/eslint-config-ckeditor5/.eslintrc.js
@@ -364,7 +364,10 @@ module.exports = {
 
 				'@typescript-eslint/explicit-module-boundary-types': [
 					'error',
-					{ allowArgumentsExplicitlyTypedAsAny: true }
+					{
+						allowedNames: [ 'requires' ],
+						allowArgumentsExplicitlyTypedAsAny: true
+					}
 				],
 
 				'@typescript-eslint/explicit-member-accessibility': [


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (eslint-config-ckeditor5): Allow 'requires' methods not to specify return type.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
