### PR TITLE
Created the `ckeditor5-rules/no-build-extensions` plugin that disallows extending a CKEditor 5 build

### DIFF
--- a/packages/eslint-config-ckeditor5/.eslintrc.js
+++ b/packages/eslint-config-ckeditor5/.eslintrc.js
@@ -482,6 +482,15 @@ module.exports = {
 			rules: {
 				'@typescript-eslint/no-unused-expressions': 'off'
 			}
+		},
+		{
+			files: [
+				'docs/**/*.@(js|ts)',
+				'packages/*/docs/**/*.@(js|ts)'
+			],
+			rules: {
+				'ckeditor5-rules/no-build-extensions': 'error'
+			}
 		}
 	]
 };

--- a/packages/eslint-plugin-ckeditor5-rules/lib/index.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/index.js
@@ -13,6 +13,7 @@ module.exports = {
 		'no-cross-package-imports': require( './rules/no-cross-package-imports' ),
 		'license-header': require( './rules/license-header' ),
 		'use-require-for-debug-mode-imports': require( './rules/use-require-for-debug-mode-imports' ),
-		'non-public-members-as-internal': require( './rules/non-public-members-as-internal' )
+		'non-public-members-as-internal': require( './rules/non-public-members-as-internal' ),
+		'no-build-extensions': require( './rules/no-build-extensions' )
 	}
 };

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/ckeditor-error-message.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/ckeditor-error-message.js
@@ -10,7 +10,9 @@ module.exports = {
 		type: 'problem',
 		docs: {
 			description: 'Disallow relative imports from CKEditor5 packages.',
-			category: 'CKEditor5'
+			category: 'CKEditor5',
+			// eslint-disable-next-line max-len
+			url: 'https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/code-style.html#description-of-an-error-ckeditor5-rulesckeditor-error-message'
 		},
 		fixable: 'code',
 		messages: {

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/ckeditor-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/ckeditor-imports.js
@@ -45,7 +45,9 @@ module.exports = {
 		type: 'problem',
 		docs: {
 			description: 'Disallow direct imports of packages that belong to CKEditor 5 DLL.',
-			category: 'CKEditor5'
+			category: 'CKEditor5',
+			// eslint-disable-next-line max-len
+			url: 'https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/code-style.html#dll-builds-ckeditor5-rulesckeditor-imports'
 		},
 		fixable: 'code',
 		schema: []

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-build-extensions.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-build-extensions.js
@@ -1,0 +1,34 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+// A regular expression that matches any import from the `src` directory in any CKEditor 5 build.
+const CKEDITOR5_IMPORT_EXTENDING_BUILD_REGEXP = /^@ckeditor\/ckeditor5-build-[^/]+\/src($|\/)/;
+
+module.exports = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Disallow import that extends a CKEditor 5 build.',
+			category: 'CKEditor5'
+		},
+		schema: []
+	},
+	create( context ) {
+		return {
+			ImportDeclaration: node => {
+				const importPath = node.source.value;
+
+				if ( CKEDITOR5_IMPORT_EXTENDING_BUILD_REGEXP.test( importPath ) ) {
+					context.report( {
+						node,
+						message: 'Import that extends a CKEditor 5 build is not allowed.'
+					} );
+				}
+			}
+		};
+	}
+};

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-build-extensions.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-build-extensions.js
@@ -13,7 +13,9 @@ module.exports = {
 		type: 'problem',
 		docs: {
 			description: 'Disallow import that extends a CKEditor 5 build.',
-			category: 'CKEditor5'
+			category: 'CKEditor5',
+			// eslint-disable-next-line max-len
+			url: 'https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/code-style.html#importing-a-predefined-build-ckeditor5-rulesno-build-extensions'
 		},
 		schema: []
 	},

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-cross-package-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-cross-package-imports.js
@@ -16,7 +16,9 @@ module.exports = {
 		type: 'problem',
 		docs: {
 			description: 'Disallow imports from CKEditor 5 in specified packages.',
-			category: 'CKEditor5'
+			category: 'CKEditor5',
+			// eslint-disable-next-line max-len
+			url: 'https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/code-style.html#cross-package-imports-ckeditor5-rulesno-cross-package-imports'
 		},
 		schema: []
 	},

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-relative-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-relative-imports.js
@@ -10,7 +10,9 @@ module.exports = {
 		type: 'problem',
 		docs: {
 			description: 'Disallow relative imports from CKEditor5 packages.',
-			category: 'CKEditor5'
+			category: 'CKEditor5',
+			// eslint-disable-next-line max-len
+			url: 'https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/code-style.html#importing-between-packages-ckeditor5-rulesno-relative-imports'
 		},
 		fixable: 'code',
 		schema: []

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/non-public-members-as-internal.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/non-public-members-as-internal.js
@@ -14,7 +14,9 @@ module.exports = {
 		type: 'problem',
 		docs: {
 			description: 'Non-public identifiers must be marked as `@internal` so that they can be removed from typings.',
-			category: 'CKEditor5'
+			category: 'CKEditor5',
+			// eslint-disable-next-line max-len
+			url: 'https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/code-style.html#non-public-members-marked-as-internal-ckeditor5-rulesnon-public-members-as-internal'
 		},
 		fixable: 'code',
 		messages: {

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/use-require-for-debug-mode-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/use-require-for-debug-mode-imports.js
@@ -23,7 +23,9 @@ module.exports = {
 		type: 'problem',
 		docs: {
 			description: 'Disallow using the `import` keyword for modules used in debug mode.',
-			category: 'CKEditor5'
+			category: 'CKEditor5',
+			// eslint-disable-next-line max-len
+			url: 'https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/code-style.html#importing-modules-in-debug-comments-ckeditor5-rulesuse-require-for-debug-mode-imports'
 		},
 		fixable: 'code',
 		messages: {

--- a/packages/eslint-plugin-ckeditor5-rules/tests/no-build-extensions.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/no-build-extensions.js
@@ -1,0 +1,54 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const RuleTester = require( 'eslint' ).RuleTester;
+
+const importError = { message: 'Import that extends a CKEditor 5 build is not allowed.' };
+
+const ruleTester = new RuleTester( { parserOptions: { sourceType: 'module', ecmaVersion: 2018 } } );
+ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-build-extensions', require( '../lib/rules/no-build-extensions' ), {
+	valid: [
+		// Importing an editor build.
+		'import ClassicEditor from \'@ckeditor/ckeditor5-build-classic\';',
+		// Importing a multi-word editor build.
+		'import MultiRootEditor from \'@ckeditor/ckeditor5-build-multi-root\';',
+		// Importing an editor class.
+		'import { ClassicEditor } from \'@ckeditor/ckeditor5-editor-classic\';',
+		// Importing a multi-word editor class.
+		'import { MultiRootEditor } from \'@ckeditor/ckeditor5-editor-multi-root\';',
+		// Importing an editor class from the "src" directory.
+		'import { MultiRootEditor } from \'@ckeditor/ckeditor5-editor-multi-root/src\';',
+		// Importing an editor class from the "src" directory (with slash at path end).
+		'import { MultiRootEditor } from \'@ckeditor/ckeditor5-editor-multi-root/src/\';'
+	],
+	invalid: [
+		{
+			code: 'import { ClassicEditor } from \'@ckeditor/ckeditor5-build-classic/src\';',
+			errors: [ importError ]
+		},
+		{
+			code: 'import { ClassicEditor } from \'@ckeditor/ckeditor5-build-classic/src/\';',
+			errors: [ importError ]
+		},
+		{
+			code: 'import ClassicEditor from \'@ckeditor/ckeditor5-build-classic/src/ckeditor\';',
+			errors: [ importError ]
+		},
+		{
+			code: 'import { MultiRootEditor } from \'@ckeditor/ckeditor5-build-multi-root/src\';',
+			errors: [ importError ]
+		},
+		{
+			code: 'import { MultiRootEditor } from \'@ckeditor/ckeditor5-build-multi-root/src/\';',
+			errors: [ importError ]
+		},
+		{
+			code: 'import MultiRootEditor from \'@ckeditor/ckeditor5-build-multi-root/src/ckeditor\';',
+			errors: [ importError ]
+		}
+	]
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (eslint-plugin-ckeditor5-rules): Created the `ckeditor5-rules/no-build-extensions` plugin that disallows extending a CKEditor 5 build. Closes ckeditor/ckeditor5#13689.

Other (eslint-plugin-ckeditor5-rules): Added URLs for rule definitions at which the full documentation can be accessed.

---

### Additional information

URL to the rule documentation is helpful, when the rule is violated. Code editors make the URL clickable:

![obraz](https://user-images.githubusercontent.com/56868128/228229988-6951a4d1-9947-4600-be70-70cf4c5dfd89.png)

PR with documentation for this new plugin: https://github.com/ckeditor/ckeditor5/pull/13776.
