### PR TITLE
Add new eslint rules to ensure good typings generation

### DIFF
--- a/packages/eslint-config-ckeditor5/.eslintrc.js
+++ b/packages/eslint-config-ckeditor5/.eslintrc.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+const METHODS_THAT_USE_AS_CONST_INSTEAD_OF_RETURN_TYPE = [ 'requires', 'pluginName' ];
+
 module.exports = {
 	extends: 'eslint:recommended',
 	parserOptions: {
@@ -368,7 +370,7 @@ module.exports = {
 				'@typescript-eslint/explicit-module-boundary-types': [
 					'error',
 					{
-						allowedNames: [ 'requires' ],
+						allowedNames: METHODS_THAT_USE_AS_CONST_INSTEAD_OF_RETURN_TYPE,
 						allowArgumentsExplicitlyTypedAsAny: true
 					}
 				],
@@ -471,7 +473,16 @@ module.exports = {
 				'@typescript-eslint/space-infix-ops': 'error',
 
 				'no-useless-constructor': 'off',
-				'@typescript-eslint/no-useless-constructor': 'error'
+				'@typescript-eslint/no-useless-constructor': 'error',
+
+				'ckeditor5-rules/allow-declare-module-only-in-augmentation-file': 'error',
+				'ckeditor5-rules/allow-imports-only-from-main-package-entry-point': 'error',
+				'ckeditor5-rules/require-as-const-returns-in-methods': [
+					'error',
+					{
+						methodNames: METHODS_THAT_USE_AS_CONST_INSTEAD_OF_RETURN_TYPE
+					}
+				]
 			}
 		},
 		{

--- a/packages/eslint-plugin-ckeditor5-rules/lib/index.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/index.js
@@ -14,6 +14,9 @@ module.exports = {
 		'license-header': require( './rules/license-header' ),
 		'use-require-for-debug-mode-imports': require( './rules/use-require-for-debug-mode-imports' ),
 		'non-public-members-as-internal': require( './rules/non-public-members-as-internal' ),
-		'no-build-extensions': require( './rules/no-build-extensions' )
+		'no-build-extensions': require( './rules/no-build-extensions' ),
+		'allow-declare-module-only-in-augmentation-file': require( './rules/allow-declare-module-only-in-augmentation-file' ),
+		'allow-imports-only-from-main-package-entry-point': require( './rules/allow-imports-only-from-main-package-entry-point.js' ),
+		'require-as-const-returns-in-methods': require( './rules/require-as-const-returns-in-methods' )
 	}
 };

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-declare-module-only-in-augmentation-file.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-declare-module-only-in-augmentation-file.js
@@ -1,0 +1,39 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+module.exports = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Allow using module augmentation for "@ckeditor/ckeditor5-core" modules only in the "/src/augmentation.ts" files.',
+			category: 'CKEditor5',
+			// eslint-disable-next-line max-len
+			url: 'https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/code-style.html#declaring-module-augmentation-for-the-core-package-allow-declare-module-only-in-augmentation-file'
+		}
+	},
+	create( context ) {
+		return {
+			TSModuleDeclaration( node ) {
+				if ( node.id.value !== '@ckeditor/ckeditor5-core' ) {
+					// Skip module declarations other than '@ckeditor/ckeditor5-core'.
+					return;
+				}
+
+				if ( context.getFilename().endsWith( '/src/augmentation.ts' ) ) {
+					// Skip if module declaration is already in the specified file.
+					return;
+				}
+
+				context.report( {
+					node,
+					// eslint-disable-next-line max-len
+					message: 'Module augmentation for the "@ckeditor/ckeditor5-core" package is only allowed in "src/augmentation.ts" files.'
+				} );
+			}
+		};
+	}
+};

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-imports-only-from-main-package-entry-point.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-imports-only-from-main-package-entry-point.js
@@ -1,0 +1,45 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+module.exports = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Allow importing from "@ckeditor/*" modules only from the main package entry point.',
+			category: 'CKEditor5',
+			// eslint-disable-next-line max-len
+			url: 'https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/code-style.html#importing-from-modules-allow-imports-only-from-main-package-entry-point'
+		},
+		schema: []
+	},
+	create( context ) {
+		return {
+			ImportDeclaration( node ) {
+				if ( node.specifiers.length === 0 ) {
+					// Ignore side-effect imports like "import '/modules/my-module.js'".
+					return;
+				}
+
+				if ( !node.source.value.startsWith( '@ckeditor/' ) ) {
+					// Ignore packages whose names don't start with '@ckeditor/'.
+					return;
+				}
+
+				if ( !node.source.value.includes( '/src/' ) ) {
+					// Ignore imports that don't include 'src'.
+					return;
+				}
+
+				context.report( {
+					node,
+					// eslint-disable-next-line max-len
+					message: 'Importing from "@ckeditor/*" packages is only allowed from the main package entry point, not from their "/src" folder.'
+				} );
+			}
+		};
+	}
+};

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/require-as-const-returns-in-methods.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/require-as-const-returns-in-methods.js
@@ -1,0 +1,105 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+module.exports = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Require the use of "as const" in all return statements for methods with given names.',
+			category: 'CKEditor5',
+			// eslint-disable-next-line max-len
+			url: 'https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/code-style.html#require-as-const-require-as-const-returns-in-methods'
+		},
+		schema: [
+			{
+				type: 'object',
+				properties: {
+					methodNames: {
+						type: 'array',
+						items: {
+							type: 'string'
+						}
+					}
+				}
+			}
+		]
+	},
+	create( context ) {
+		const methodNames = context.options[ 0 ] ? context.options[ 0 ].methodNames : null;
+		let inMethod = false;
+		const returnStatements = [];
+
+		function showError( node ) {
+			context.report( {
+				node,
+				message: 'Not all return statements end with "as const".'
+			} );
+		}
+
+		return {
+			MethodDefinition( node ) {
+				if ( node.accessibility !== 'public' ) {
+					// Skip non-public methods.
+					return;
+				}
+
+				if ( node.value.type === 'TSEmptyBodyFunctionExpression' ) {
+					// Skip methods without a body.
+					return;
+				}
+
+				if ( methodNames && !methodNames.includes( node.key.name ) ) {
+					// Skip methods if their name don't match provided names.
+					return;
+				}
+
+				if ( node.value.returnType ) {
+					context.report( {
+						node,
+						message: 'Methods that require return statements to end with "as const" cannot specify a return type.'
+					} );
+				}
+
+				inMethod = true;
+			},
+
+			ReturnStatement( node ) {
+				if ( !inMethod ) {
+					return;
+				}
+
+				returnStatements.push( node );
+			},
+
+			'MethodDefinition:exit'( node ) {
+				if ( !inMethod ) {
+					return;
+				}
+
+				inMethod = false;
+
+				if ( !returnStatements.length ) {
+					return showError( node );
+				}
+
+				const allReturnStatementsUseAsConst = returnStatements.every( ( { argument } ) => {
+					return argument &&
+						argument.type === 'TSAsExpression' &&
+						argument.typeAnnotation &&
+						argument.typeAnnotation.typeName &&
+						argument.typeAnnotation.typeName.name === 'const';
+				} );
+
+				if ( allReturnStatementsUseAsConst ) {
+					return;
+				}
+
+				showError( node );
+			}
+		};
+	}
+};

--- a/packages/eslint-plugin-ckeditor5-rules/tests/allow-declare-module-only-in-augmentation-file.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/allow-declare-module-only-in-augmentation-file.js
@@ -1,0 +1,37 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const RuleTester = require( 'eslint' ).RuleTester;
+
+const ruleTester = new RuleTester( {
+	parser: require.resolve( '@typescript-eslint/parser' )
+} );
+
+ruleTester.run(
+	'allow-declare-module-only-in-augmentation-file',
+	require( '../lib/rules/allow-declare-module-only-in-augmentation-file' ),
+	{
+		valid: [
+			{
+				code: 'declare module "@ckeditor/ckeditor5-core" {}',
+				filename: '/some/path/src/augmentation.ts'
+			}
+		],
+		invalid: [
+			{
+				code: 'declare module "@ckeditor/ckeditor5-core" {}',
+				filename: '/some/path/src/invalid.ts',
+				errors: [
+					{
+						// eslint-disable-next-line max-len
+						message: 'Module augmentation for the "@ckeditor/ckeditor5-core" package is only allowed in "src/augmentation.ts" files.'
+					}
+				]
+			}
+		]
+	}
+);

--- a/packages/eslint-plugin-ckeditor5-rules/tests/allow-imports-only-from-main-package-entry-point.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/allow-imports-only-from-main-package-entry-point.js
@@ -1,0 +1,33 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const RuleTester = require( 'eslint' ).RuleTester;
+
+const ruleTester = new RuleTester( {
+	parserOptions: { sourceType: 'module', ecmaVersion: 2018 }
+} );
+
+ruleTester.run(
+	'allow-imports-only-from-main-package-entry-point',
+	require( '../lib/rules/allow-imports-only-from-main-package-entry-point.js' ),
+	{
+		valid: [
+			'import { Table } from "@ckeditor/ckeditor5-table";'
+		],
+		invalid: [
+			{
+				code: 'import Table from "@ckeditor/ckeditor5-table/src/table";',
+				errors: [
+					{
+						// eslint-disable-next-line max-len
+						message: 'Importing from "@ckeditor/*" packages is only allowed from the main package entry point, not from their "/src" folder.'
+					}
+				]
+			}
+		]
+	}
+);

--- a/packages/eslint-plugin-ckeditor5-rules/tests/require-as-const-returns-in-methods.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/require-as-const-returns-in-methods.js
@@ -1,0 +1,82 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const RuleTester = require( 'eslint' ).RuleTester;
+
+const ruleTester = new RuleTester( {
+	parser: require.resolve( '@typescript-eslint/parser' )
+} );
+
+ruleTester.run( 'require-as-const-returns-in-methods', require( '../lib/rules/require-as-const-returns-in-methods' ), {
+	valid: [
+		{
+			code: `
+				class Test {
+					public test() {
+						return 123;
+					}
+				}
+			`,
+			filename: '/some/path/src/augmentation.ts',
+			options: [
+				{ methodNames: [] }
+			]
+		},
+		{
+			code: `
+				class Test {
+					public test() {
+						return 123 as const;
+					}
+				}
+			`,
+			filename: '/some/path/src/augmentation.ts',
+			options: [
+				{ methodNames: [ 'test' ] }
+			]
+		}
+	],
+	invalid: [
+		{
+			code: `
+				class Test {
+					public test() {
+						return 123;
+					}
+				}
+			`,
+			filename: '/some/path/src/augmentation.ts',
+			options: [
+				{ methodNames: [ 'test' ] }
+			],
+			errors: [
+				{
+					message: 'Not all return statements end with "as const".'
+				}
+			]
+		},
+
+		{
+			code: `
+				class Test {
+					public test(): string {
+						return 123 as const;
+					}
+				}
+			`,
+			filename: '/some/path/src/augmentation.ts',
+			options: [
+				{ methodNames: [ 'test' ] }
+			],
+			errors: [
+				{
+					message: 'Methods that require return statements to end with "as const" cannot specify a return type.'
+				}
+			]
+		}
+	]
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (eslint-plugin-ckeditor5-rules): Created the `ckeditor5-rules/allow-declare-module-only-in-augmentation-file` plugin that enforces using module augmentation for the `@ckeditor/ckeditor5-core` modules only in the augmentation files. Related to ckeditor/ckeditor5#13434.

Feature (eslint-plugin-ckeditor5-rules): Created the `ckeditor5-rules/allow-imports-only-from-main-package-entry-point` plugin that allows imports from the `@ckeditor/*` modules only from the main package entry point. Related to ckeditor/ckeditor5#13434.

Feature (eslint-plugin-ckeditor5-rules): Created the `ckeditor5-rules/require-as-const-returns-in-methods` plugin that enforces using the `as const` in return statements for `requires` and `pluginName` methods. Related to ckeditor/ckeditor5#13434.

Other (eslint-config-ckeditor5): Enabled the `ckeditor5-rules/allow-declare-module-only-in-augmentation-file` in the ESLint configuration.

Other (eslint-config-ckeditor5): Enabled the `ckeditor5-rules/allow-imports-only-from-main-package-entry-point` in the ESLint configuration.

Other (eslint-config-ckeditor5): Enabled the `ckeditor5-rules/require-as-const-returns-in-methods` in the ESLint configuration.
