### PR TITLE
Added ESLint rule to enforce relative imports within the same package

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@ckeditor/ckeditor5-dev-release-tools": "^38.0.0",
     "eslint": "^7.0.0",
     "husky": "^8.0.2",
-    "lint-staged": "^12.0.0",
+    "lint-staged": "^13.0.0",
     "listr2": "^6.5.0"
   },
   "lint-staged": {

--- a/packages/eslint-config-ckeditor5/.eslintrc.js
+++ b/packages/eslint-config-ckeditor5/.eslintrc.js
@@ -10,7 +10,7 @@ const METHODS_THAT_USE_AS_CONST_INSTEAD_OF_RETURN_TYPE = [ 'requires', 'pluginNa
 module.exports = {
 	extends: 'eslint:recommended',
 	parserOptions: {
-		ecmaVersion: 2018,
+		ecmaVersion: 2020,
 		sourceType: 'module'
 	},
 	env: {
@@ -314,6 +314,7 @@ module.exports = {
 		'ckeditor5-rules/no-relative-imports': 'error',
 		'ckeditor5-rules/ckeditor-error-message': 'error',
 		'ckeditor5-rules/no-cross-package-imports': 'error',
+		'ckeditor5-rules/no-scoped-imports-within-package': 'error',
 		'ckeditor5-rules/use-require-for-debug-mode-imports': 'error',
 		'ckeditor5-rules/no-istanbul-in-debug-code': 'error',
 
@@ -506,6 +507,15 @@ module.exports = {
 			],
 			rules: {
 				'ckeditor5-rules/no-build-extensions': 'error'
+			}
+		},
+		{
+			files: [
+				'**/docs/**/*.@(js|ts)',
+				'**/tests/**/*.@(js|ts)'
+			],
+			rules: {
+				'ckeditor5-rules/no-scoped-imports-within-package': 'off'
 			}
 		}
 	]

--- a/packages/eslint-plugin-ckeditor5-rules/lib/index.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/index.js
@@ -11,6 +11,7 @@ module.exports = {
 		'ckeditor-error-message': require( './rules/ckeditor-error-message' ),
 		'ckeditor-imports': require( './rules/ckeditor-imports' ),
 		'no-cross-package-imports': require( './rules/no-cross-package-imports' ),
+		'no-scoped-imports-within-package': require( './rules/no-scoped-imports-within-package' ),
 		'license-header': require( './rules/license-header' ),
 		'use-require-for-debug-mode-imports': require( './rules/use-require-for-debug-mode-imports' ),
 		'non-public-members-as-internal': require( './rules/non-public-members-as-internal' ),

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-scoped-imports-within-package.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-scoped-imports-within-package.js
@@ -1,0 +1,97 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const upath = require( 'upath' );
+const fs = require( 'fs-extra' );
+
+module.exports = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Disallow scoped import like "@ckeditor/*" to the same package where the import declaration is located.',
+			category: 'CKEditor5',
+			// eslint-disable-next-line max-len
+			url: 'https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/code-style.html#imports-within-a-package-ckeditor5-rulesno-scoped-imports-within-package'
+		},
+		schema: []
+	},
+	create( context ) {
+		const handler = callbackFactory( context );
+
+		return {
+			ImportDeclaration: handler,
+			ExportNamedDeclaration: handler,
+			ExportAllDeclaration: handler
+		};
+	}
+};
+
+/**
+ * @param {Object} context
+ * @return {Function}
+ */
+function callbackFactory( context ) {
+	return node => {
+		if ( !node.source ) {
+			return;
+		}
+
+		const importedPackageName = node.source.value;
+
+		const isScopedImport =
+			importedPackageName.startsWith( '@ckeditor/ckeditor5' ) ||
+			importedPackageName.startsWith( 'ckeditor5' );
+
+		if ( !isScopedImport ) {
+			return;
+		}
+
+		const directory = upath.dirname( context.getFilename() );
+		const cwd = upath.normalizeTrim( context.getCwd() );
+		const packageName = getPackageName( directory, cwd );
+
+		if ( !packageName ) {
+			return;
+		}
+
+		const isScopedImportToSamePackage =
+			importedPackageName === packageName ||
+			importedPackageName.startsWith( `${ packageName }/` );
+
+		if ( isScopedImportToSamePackage ) {
+			context.report( {
+				node,
+				message: 'Scoped import like "@ckeditor/*" to the same package where the import declaration is located is disallowed.'
+			} );
+		}
+	};
+}
+
+/**
+ * @param {String} directory
+ * @param {String} cwd
+ * @return {String|null}
+ */
+function getPackageName( directory, cwd ) {
+	const packageJsonPath = upath.join( directory, 'package.json' );
+
+	if ( fs.pathExistsSync( packageJsonPath ) ) {
+		const packageJson = fs.readJsonSync( packageJsonPath, { throws: false } );
+
+		if ( packageJson ) {
+			return packageJson.name;
+		}
+	}
+
+	const parentDirectory = upath.dirname( directory );
+
+	if ( parentDirectory.startsWith( cwd ) ) {
+		return getPackageName( parentDirectory, cwd );
+	}
+
+	return null;
+}

--- a/packages/eslint-plugin-ckeditor5-rules/package.json
+++ b/packages/eslint-plugin-ckeditor5-rules/package.json
@@ -28,13 +28,17 @@
   },
   "devDependencies": {
     "eslint": "^7.0.0",
-    "eslint-config-ckeditor5": "^4.4.0"
+    "eslint-config-ckeditor5": "^4.4.0",
+    "glob": "^10.2.5",
+    "lodash": "^4.17.21"
   },
   "peerDependencies": {
     "eslint": ">=7.0.0"
   },
   "dependencies": {
     "@es-joy/jsdoccomment": "^0.36.1",
-    "@typescript-eslint/parser": "^5.52.0"
+    "@typescript-eslint/parser": "^5.52.0",
+    "fs-extra": "^11.1.1",
+    "upath": "^2.0.1"
   }
 }

--- a/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/invalid/packages/ckeditor5-feature-nested/package.json
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/invalid/packages/ckeditor5-feature-nested/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@ckeditor/ckeditor5-feature-nested"
+}

--- a/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/invalid/packages/ckeditor5-feature-nested/src/a/b/c/scoped-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/invalid/packages/ckeditor5-feature-nested/src/a/b/c/scoped-imports.js
@@ -1,0 +1,32 @@
+import name1 from '@ckeditor/ckeditor5-feature-nested';
+import name2 from '@ckeditor/ckeditor5-feature-nested/src';
+
+import * as name3 from '@ckeditor/ckeditor5-feature-nested';
+import * as name4 from '@ckeditor/ckeditor5-feature-nested/src';
+
+import { name5 } from '@ckeditor/ckeditor5-feature-nested';
+import { name6 } from '@ckeditor/ckeditor5-feature-nested/src';
+
+import { name as name7 } from '@ckeditor/ckeditor5-feature-nested';
+import { name as name8 } from '@ckeditor/ckeditor5-feature-nested/src';
+
+import { default as name9 } from '@ckeditor/ckeditor5-feature-nested';
+import { default as name10 } from '@ckeditor/ckeditor5-feature-nested/src';
+
+import '@ckeditor/ckeditor5-feature-nested';
+import '@ckeditor/ckeditor5-feature-nested/src';
+
+export * from '@ckeditor/ckeditor5-feature-nested';
+export * from '@ckeditor/ckeditor5-feature-nested/src';
+
+export * as name11 from '@ckeditor/ckeditor5-feature-nested';
+export * as name12 from '@ckeditor/ckeditor5-feature-nested/src';
+
+export { name13 } from '@ckeditor/ckeditor5-feature-nested';
+export { name14 } from '@ckeditor/ckeditor5-feature-nested/src';
+
+export { name as name15 } from '@ckeditor/ckeditor5-feature-nested';
+export { name as name16 } from '@ckeditor/ckeditor5-feature-nested/src';
+
+export { default as name17 } from '@ckeditor/ckeditor5-feature-nested';
+export { default as name18 } from '@ckeditor/ckeditor5-feature-nested/src';

--- a/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/invalid/packages/ckeditor5-feature-short/package.json
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/invalid/packages/ckeditor5-feature-short/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "ckeditor5-feature-short"
+}

--- a/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/invalid/packages/ckeditor5-feature-short/scoped-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/invalid/packages/ckeditor5-feature-short/scoped-imports.js
@@ -1,0 +1,32 @@
+import name1 from 'ckeditor5-feature-short';
+import name2 from 'ckeditor5-feature-short/src';
+
+import * as name3 from 'ckeditor5-feature-short';
+import * as name4 from 'ckeditor5-feature-short/src';
+
+import { name5 } from 'ckeditor5-feature-short';
+import { name6 } from 'ckeditor5-feature-short/src';
+
+import { name as name7 } from 'ckeditor5-feature-short';
+import { name as name8 } from 'ckeditor5-feature-short/src';
+
+import { default as name9 } from 'ckeditor5-feature-short';
+import { default as name10 } from 'ckeditor5-feature-short/src';
+
+import 'ckeditor5-feature-short';
+import 'ckeditor5-feature-short/src';
+
+export * from 'ckeditor5-feature-short';
+export * from 'ckeditor5-feature-short/src';
+
+export * as name11 from 'ckeditor5-feature-short';
+export * as name12 from 'ckeditor5-feature-short/src';
+
+export { name13 } from 'ckeditor5-feature-short';
+export { name14 } from 'ckeditor5-feature-short/src';
+
+export { name as name15 } from 'ckeditor5-feature-short';
+export { name as name16 } from 'ckeditor5-feature-short/src';
+
+export { default as name17 } from 'ckeditor5-feature-short';
+export { default as name18 } from 'ckeditor5-feature-short/src';

--- a/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/invalid/packages/ckeditor5-feature/package.json
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/invalid/packages/ckeditor5-feature/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@ckeditor/ckeditor5-feature"
+}

--- a/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/invalid/packages/ckeditor5-feature/scoped-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/invalid/packages/ckeditor5-feature/scoped-imports.js
@@ -1,0 +1,32 @@
+import name1 from '@ckeditor/ckeditor5-feature';
+import name2 from '@ckeditor/ckeditor5-feature/src';
+
+import * as name3 from '@ckeditor/ckeditor5-feature';
+import * as name4 from '@ckeditor/ckeditor5-feature/src';
+
+import { name5 } from '@ckeditor/ckeditor5-feature';
+import { name6 } from '@ckeditor/ckeditor5-feature/src';
+
+import { name as name7 } from '@ckeditor/ckeditor5-feature';
+import { name as name8 } from '@ckeditor/ckeditor5-feature/src';
+
+import { default as name9 } from '@ckeditor/ckeditor5-feature';
+import { default as name10 } from '@ckeditor/ckeditor5-feature/src';
+
+import '@ckeditor/ckeditor5-feature';
+import '@ckeditor/ckeditor5-feature/src';
+
+export * from '@ckeditor/ckeditor5-feature';
+export * from '@ckeditor/ckeditor5-feature/src';
+
+export * as name11 from '@ckeditor/ckeditor5-feature';
+export * as name12 from '@ckeditor/ckeditor5-feature/src';
+
+export { name13 } from '@ckeditor/ckeditor5-feature';
+export { name14 } from '@ckeditor/ckeditor5-feature/src';
+
+export { name as name15 } from '@ckeditor/ckeditor5-feature';
+export { name as name16 } from '@ckeditor/ckeditor5-feature/src';
+
+export { default as name17 } from '@ckeditor/ckeditor5-feature';
+export { default as name18 } from '@ckeditor/ckeditor5-feature/src';

--- a/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-feature-nested/package.json
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-feature-nested/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@ckeditor/ckeditor5-feature-nested"
+}

--- a/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-feature-nested/src/a/b/c/no-scoped-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-feature-nested/src/a/b/c/no-scoped-imports.js
@@ -1,0 +1,43 @@
+import name1 from 'no-scoped-import';
+import name2 from './no-scoped-imports';
+import name3 from '../no-scoped-import';
+
+import * as name4 from 'no-scoped-import';
+import * as name5 from './no-scoped-imports';
+import * as name6 from '../no-scoped-import';
+
+import { name7 } from 'no-scoped-import';
+import { name8 } from './no-scoped-imports';
+import { name9 } from '../no-scoped-import';
+
+import { name as name10 } from 'no-scoped-import';
+import { name as name11 } from './no-scoped-imports';
+import { name as name12 } from '../no-scoped-import';
+
+import { default as name13 } from 'no-scoped-import';
+import { default as name14 } from './no-scoped-imports';
+import { default as name15 } from '../no-scoped-import';
+
+import 'no-scoped-import';
+import './no-scoped-imports';
+import '../no-scoped-import';
+
+export * from 'no-scoped-import';
+export * from './no-scoped-imports';
+export * from '../no-scoped-import';
+
+export * as name16 from 'no-scoped-import';
+export * as name17 from './no-scoped-imports';
+export * as name18 from '../no-scoped-import';
+
+export { name19 } from 'no-scoped-import';
+export { name20 } from './no-scoped-imports';
+export { name21 } from '../no-scoped-import';
+
+export { name as name22 } from 'no-scoped-import';
+export { name as name23 } from './no-scoped-imports';
+export { name as name24 } from '../no-scoped-import';
+
+export { default as name25 } from 'no-scoped-import';
+export { default as name26 } from './no-scoped-imports';
+export { default as name27 } from '../no-scoped-import';

--- a/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-feature-nested/src/a/b/c/scoped-imports-not-to-self.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-feature-nested/src/a/b/c/scoped-imports-not-to-self.js
@@ -1,0 +1,98 @@
+import name1 from 'ckeditor5';
+import name2 from 'ckeditor5/src';
+import name3 from 'ckeditor5-feature-nested';
+import name4 from 'ckeditor5-feature-nested/src';
+import name5 from '@ckeditor/ckeditor5-feature-nestedsuffix';
+import name6 from '@ckeditor/ckeditor5-feature-nestedsuffix/src';
+import name7 from '@ckeditor/ckeditor5-feature-nested-suffix';
+import name8 from '@ckeditor/ckeditor5-feature-nested-suffix/src';
+
+import * as name9 from 'ckeditor5';
+import * as name10 from 'ckeditor5/src';
+import * as name11 from 'ckeditor5-feature-nested';
+import * as name12 from 'ckeditor5-feature-nested/src';
+import * as name13 from '@ckeditor/ckeditor5-feature-nestedsuffix';
+import * as name14 from '@ckeditor/ckeditor5-feature-nestedsuffix/src';
+import * as name15 from '@ckeditor/ckeditor5-feature-nested-suffix';
+import * as name16 from '@ckeditor/ckeditor5-feature-nested-suffix/src';
+
+import { name17 } from 'ckeditor5';
+import { name18 } from 'ckeditor5/src';
+import { name19 } from 'ckeditor5-feature-nested';
+import { name20 } from 'ckeditor5-feature-nested/src';
+import { name21 } from '@ckeditor/ckeditor5-feature-nestedsuffix';
+import { name22 } from '@ckeditor/ckeditor5-feature-nestedsuffix/src';
+import { name23 } from '@ckeditor/ckeditor5-feature-nested-suffix';
+import { name24 } from '@ckeditor/ckeditor5-feature-nested-suffix/src';
+
+import { name as name25 } from 'ckeditor5';
+import { name as name26 } from 'ckeditor5/src';
+import { name as name27 } from 'ckeditor5-feature-nested';
+import { name as name28 } from 'ckeditor5-feature-nested/src';
+import { name as name29 } from '@ckeditor/ckeditor5-feature-nestedsuffix';
+import { name as name30 } from '@ckeditor/ckeditor5-feature-nestedsuffix/src';
+import { name as name31 } from '@ckeditor/ckeditor5-feature-nested-suffix';
+import { name as name32 } from '@ckeditor/ckeditor5-feature-nested-suffix/src';
+
+import { default as name33 } from 'ckeditor5';
+import { default as name34 } from 'ckeditor5/src';
+import { default as name35 } from 'ckeditor5-feature-nested';
+import { default as name36 } from 'ckeditor5-feature-nested/src';
+import { default as name37 } from '@ckeditor/ckeditor5-feature-nestedsuffix';
+import { default as name38 } from '@ckeditor/ckeditor5-feature-nestedsuffix/src';
+import { default as name39 } from '@ckeditor/ckeditor5-feature-nested-suffix';
+import { default as name40 } from '@ckeditor/ckeditor5-feature-nested-suffix/src';
+
+import 'ckeditor5';
+import 'ckeditor5/src';
+import 'ckeditor5-feature-nested';
+import 'ckeditor5-feature-nested/src';
+import '@ckeditor/ckeditor5-feature-nestedsuffix';
+import '@ckeditor/ckeditor5-feature-nestedsuffix/src';
+import '@ckeditor/ckeditor5-feature-nested-suffix';
+import '@ckeditor/ckeditor5-feature-nested-suffix/src';
+
+export * from 'ckeditor5';
+export * from 'ckeditor5/src';
+export * from 'ckeditor5-feature-nested';
+export * from 'ckeditor5-feature-nested/src';
+export * from '@ckeditor/ckeditor5-feature-nestedsuffix';
+export * from '@ckeditor/ckeditor5-feature-nestedsuffix/src';
+export * from '@ckeditor/ckeditor5-feature-nested-suffix';
+export * from '@ckeditor/ckeditor5-feature-nested-suffix/src';
+
+export * as name41 from 'ckeditor5';
+export * as name42 from 'ckeditor5/src';
+export * as name43 from 'ckeditor5-feature-nested';
+export * as name44 from 'ckeditor5-feature-nested/src';
+export * as name45 from '@ckeditor/ckeditor5-feature-nestedsuffix';
+export * as name46 from '@ckeditor/ckeditor5-feature-nestedsuffix/src';
+export * as name47 from '@ckeditor/ckeditor5-feature-nested-suffix';
+export * as name48 from '@ckeditor/ckeditor5-feature-nested-suffix/src';
+
+export { name49 } from 'ckeditor5';
+export { name50 } from 'ckeditor5/src';
+export { name51 } from 'ckeditor5-feature-nested';
+export { name52 } from 'ckeditor5-feature-nested/src';
+export { name53 } from '@ckeditor/ckeditor5-feature-nestedsuffix';
+export { name54 } from '@ckeditor/ckeditor5-feature-nestedsuffix/src';
+export { name55 } from '@ckeditor/ckeditor5-feature-nested-suffix';
+export { name56 } from '@ckeditor/ckeditor5-feature-nested-suffix/src';
+
+export { name as name57 } from 'ckeditor5';
+export { name as name58 } from 'ckeditor5/src';
+export { name as name59 } from 'ckeditor5-feature-nested';
+export { name as name60 } from 'ckeditor5-feature-nested/src';
+export { name as name61 } from '@ckeditor/ckeditor5-feature-nestedsuffix';
+export { name as name62 } from '@ckeditor/ckeditor5-feature-nestedsuffix/src';
+export { name as name63 } from '@ckeditor/ckeditor5-feature-nested-suffix';
+export { name as name64 } from '@ckeditor/ckeditor5-feature-nested-suffix/src';
+
+export { default as name65 } from 'ckeditor5';
+export { default as name66 } from 'ckeditor5/src';
+export { default as name67 } from 'ckeditor5-feature-nested';
+export { default as name68 } from 'ckeditor5-feature-nested/src';
+export { default as name69 } from '@ckeditor/ckeditor5-feature-nestedsuffix';
+export { default as name70 } from '@ckeditor/ckeditor5-feature-nestedsuffix/src';
+export { default as name71 } from '@ckeditor/ckeditor5-feature-nested-suffix';
+export { default as name72 } from '@ckeditor/ckeditor5-feature-nested-suffix/src';

--- a/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-feature-short/no-scoped-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-feature-short/no-scoped-imports.js
@@ -1,0 +1,43 @@
+import name1 from 'no-scoped-import';
+import name2 from './no-scoped-imports';
+import name3 from '../no-scoped-import';
+
+import * as name4 from 'no-scoped-import';
+import * as name5 from './no-scoped-imports';
+import * as name6 from '../no-scoped-import';
+
+import { name7 } from 'no-scoped-import';
+import { name8 } from './no-scoped-imports';
+import { name9 } from '../no-scoped-import';
+
+import { name as name10 } from 'no-scoped-import';
+import { name as name11 } from './no-scoped-imports';
+import { name as name12 } from '../no-scoped-import';
+
+import { default as name13 } from 'no-scoped-import';
+import { default as name14 } from './no-scoped-imports';
+import { default as name15 } from '../no-scoped-import';
+
+import 'no-scoped-import';
+import './no-scoped-imports';
+import '../no-scoped-import';
+
+export * from 'no-scoped-import';
+export * from './no-scoped-imports';
+export * from '../no-scoped-import';
+
+export * as name16 from 'no-scoped-import';
+export * as name17 from './no-scoped-imports';
+export * as name18 from '../no-scoped-import';
+
+export { name19 } from 'no-scoped-import';
+export { name20 } from './no-scoped-imports';
+export { name21 } from '../no-scoped-import';
+
+export { name as name22 } from 'no-scoped-import';
+export { name as name23 } from './no-scoped-imports';
+export { name as name24 } from '../no-scoped-import';
+
+export { default as name25 } from 'no-scoped-import';
+export { default as name26 } from './no-scoped-imports';
+export { default as name27 } from '../no-scoped-import';

--- a/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-feature-short/package.json
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-feature-short/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "ckeditor5-feature-short"
+}

--- a/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-feature-short/scoped-imports-not-to-self.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-feature-short/scoped-imports-not-to-self.js
@@ -1,0 +1,98 @@
+import name1 from 'ckeditor5';
+import name2 from 'ckeditor5/src';
+import name3 from 'ckeditor5-feature-shortsuffix';
+import name4 from 'ckeditor5-feature-shortsuffix/src';
+import name5 from 'ckeditor5-feature-short-suffix';
+import name6 from 'ckeditor5-feature-short-suffix/src';
+import name7 from '@ckeditor/ckeditor5-feature-short';
+import name8 from '@ckeditor/ckeditor5-feature-short/src';
+
+import * as name9 from 'ckeditor5';
+import * as name10 from 'ckeditor5/src';
+import * as name11 from 'ckeditor5-feature-shortsuffix';
+import * as name12 from 'ckeditor5-feature-shortsuffix/src';
+import * as name13 from 'ckeditor5-feature-short-suffix';
+import * as name14 from 'ckeditor5-feature-short-suffix/src';
+import * as name15 from '@ckeditor/ckeditor5-feature-short';
+import * as name16 from '@ckeditor/ckeditor5-feature-short/src';
+
+import { name17 } from 'ckeditor5';
+import { name18 } from 'ckeditor5/src';
+import { name19 } from 'ckeditor5-feature-shortsuffix';
+import { name20 } from 'ckeditor5-feature-shortsuffix/src';
+import { name21 } from 'ckeditor5-feature-short-suffix';
+import { name22 } from 'ckeditor5-feature-short-suffix/src';
+import { name23 } from '@ckeditor/ckeditor5-feature-short';
+import { name24 } from '@ckeditor/ckeditor5-feature-short/src';
+
+import { name as name25 } from 'ckeditor5';
+import { name as name26 } from 'ckeditor5/src';
+import { name as name27 } from 'ckeditor5-feature-shortsuffix';
+import { name as name28 } from 'ckeditor5-feature-shortsuffix/src';
+import { name as name29 } from 'ckeditor5-feature-short-suffix';
+import { name as name30 } from 'ckeditor5-feature-short-suffix/src';
+import { name as name31 } from '@ckeditor/ckeditor5-feature-short';
+import { name as name32 } from '@ckeditor/ckeditor5-feature-short/src';
+
+import { default as name33 } from 'ckeditor5';
+import { default as name34 } from 'ckeditor5/src';
+import { default as name35 } from 'ckeditor5-feature-shortsuffix';
+import { default as name36 } from 'ckeditor5-feature-shortsuffix/src';
+import { default as name37 } from 'ckeditor5-feature-short-suffix';
+import { default as name38 } from 'ckeditor5-feature-short-suffix/src';
+import { default as name39 } from '@ckeditor/ckeditor5-feature-short';
+import { default as name40 } from '@ckeditor/ckeditor5-feature-short/src';
+
+import 'ckeditor5';
+import 'ckeditor5/src';
+import 'ckeditor5-feature-shortsuffix';
+import 'ckeditor5-feature-shortsuffix/src';
+import 'ckeditor5-feature-short-suffix';
+import 'ckeditor5-feature-short-suffix/src';
+import '@ckeditor/ckeditor5-feature-short';
+import '@ckeditor/ckeditor5-feature-short/src';
+
+export * from 'ckeditor5';
+export * from 'ckeditor5/src';
+export * from 'ckeditor5-feature-shortsuffix';
+export * from 'ckeditor5-feature-shortsuffix/src';
+export * from 'ckeditor5-feature-short-suffix';
+export * from 'ckeditor5-feature-short-suffix/src';
+export * from '@ckeditor/ckeditor5-feature-short';
+export * from '@ckeditor/ckeditor5-feature-short/src';
+
+export * as name41 from 'ckeditor5';
+export * as name42 from 'ckeditor5/src';
+export * as name43 from 'ckeditor5-feature-shortsuffix';
+export * as name44 from 'ckeditor5-feature-shortsuffix/src';
+export * as name45 from 'ckeditor5-feature-short-suffix';
+export * as name46 from 'ckeditor5-feature-short-suffix/src';
+export * as name47 from '@ckeditor/ckeditor5-feature-short';
+export * as name48 from '@ckeditor/ckeditor5-feature-short/src';
+
+export { name49 } from 'ckeditor5';
+export { name50 } from 'ckeditor5/src';
+export { name51 } from 'ckeditor5-feature-shortsuffix';
+export { name52 } from 'ckeditor5-feature-shortsuffix/src';
+export { name53 } from 'ckeditor5-feature-short-suffix';
+export { name54 } from 'ckeditor5-feature-short-suffix/src';
+export { name55 } from '@ckeditor/ckeditor5-feature-short';
+export { name56 } from '@ckeditor/ckeditor5-feature-short/src';
+
+export { name as name57 } from 'ckeditor5';
+export { name as name58 } from 'ckeditor5/src';
+export { name as name59 } from 'ckeditor5-feature-shortsuffix';
+export { name as name60 } from 'ckeditor5-feature-shortsuffix/src';
+export { name as name61 } from 'ckeditor5-feature-short-suffix';
+export { name as name62 } from 'ckeditor5-feature-short-suffix/src';
+export { name as name63 } from '@ckeditor/ckeditor5-feature-short';
+export { name as name64 } from '@ckeditor/ckeditor5-feature-short/src';
+
+export { default as name65 } from 'ckeditor5';
+export { default as name66 } from 'ckeditor5/src';
+export { default as name67 } from 'ckeditor5-feature-shortsuffix';
+export { default as name68 } from 'ckeditor5-feature-shortsuffix/src';
+export { default as name69 } from 'ckeditor5-feature-short-suffix';
+export { default as name70 } from 'ckeditor5-feature-short-suffix/src';
+export { default as name71 } from '@ckeditor/ckeditor5-feature-short';
+export { default as name72 } from '@ckeditor/ckeditor5-feature-short/src';

--- a/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-feature/no-scoped-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-feature/no-scoped-imports.js
@@ -1,0 +1,43 @@
+import name1 from 'no-scoped-import';
+import name2 from './no-scoped-imports';
+import name3 from '../no-scoped-import';
+
+import * as name4 from 'no-scoped-import';
+import * as name5 from './no-scoped-imports';
+import * as name6 from '../no-scoped-import';
+
+import { name7 } from 'no-scoped-import';
+import { name8 } from './no-scoped-imports';
+import { name9 } from '../no-scoped-import';
+
+import { name as name10 } from 'no-scoped-import';
+import { name as name11 } from './no-scoped-imports';
+import { name as name12 } from '../no-scoped-import';
+
+import { default as name13 } from 'no-scoped-import';
+import { default as name14 } from './no-scoped-imports';
+import { default as name15 } from '../no-scoped-import';
+
+import 'no-scoped-import';
+import './no-scoped-imports';
+import '../no-scoped-import';
+
+export * from 'no-scoped-import';
+export * from './no-scoped-imports';
+export * from '../no-scoped-import';
+
+export * as name16 from 'no-scoped-import';
+export * as name17 from './no-scoped-imports';
+export * as name18 from '../no-scoped-import';
+
+export { name19 } from 'no-scoped-import';
+export { name20 } from './no-scoped-imports';
+export { name21 } from '../no-scoped-import';
+
+export { name as name22 } from 'no-scoped-import';
+export { name as name23 } from './no-scoped-imports';
+export { name as name24 } from '../no-scoped-import';
+
+export { default as name25 } from 'no-scoped-import';
+export { default as name26 } from './no-scoped-imports';
+export { default as name27 } from '../no-scoped-import';

--- a/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-feature/package.json
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-feature/package.json
@@ -1,0 +1,3 @@
+{
+  "name": "@ckeditor/ckeditor5-feature"
+}

--- a/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-feature/scoped-imports-not-to-self.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-feature/scoped-imports-not-to-self.js
@@ -1,0 +1,98 @@
+import name1 from 'ckeditor5';
+import name2 from 'ckeditor5/src';
+import name3 from 'ckeditor5-feature';
+import name4 from 'ckeditor5-feature/src';
+import name5 from '@ckeditor/ckeditor5-featuresuffix';
+import name6 from '@ckeditor/ckeditor5-featuresuffix/src';
+import name7 from '@ckeditor/ckeditor5-feature-suffix';
+import name8 from '@ckeditor/ckeditor5-feature-suffix/src';
+
+import * as name9 from 'ckeditor5';
+import * as name10 from 'ckeditor5/src';
+import * as name11 from 'ckeditor5-feature';
+import * as name12 from 'ckeditor5-feature/src';
+import * as name13 from '@ckeditor/ckeditor5-featuresuffix';
+import * as name14 from '@ckeditor/ckeditor5-featuresuffix/src';
+import * as name15 from '@ckeditor/ckeditor5-feature-suffix';
+import * as name16 from '@ckeditor/ckeditor5-feature-suffix/src';
+
+import { name17 } from 'ckeditor5';
+import { name18 } from 'ckeditor5/src';
+import { name19 } from 'ckeditor5-feature';
+import { name20 } from 'ckeditor5-feature/src';
+import { name21 } from '@ckeditor/ckeditor5-featuresuffix';
+import { name22 } from '@ckeditor/ckeditor5-featuresuffix/src';
+import { name23 } from '@ckeditor/ckeditor5-feature-suffix';
+import { name24 } from '@ckeditor/ckeditor5-feature-suffix/src';
+
+import { name as name25 } from 'ckeditor5';
+import { name as name26 } from 'ckeditor5/src';
+import { name as name27 } from 'ckeditor5-feature';
+import { name as name28 } from 'ckeditor5-feature/src';
+import { name as name29 } from '@ckeditor/ckeditor5-featuresuffix';
+import { name as name30 } from '@ckeditor/ckeditor5-featuresuffix/src';
+import { name as name31 } from '@ckeditor/ckeditor5-feature-suffix';
+import { name as name32 } from '@ckeditor/ckeditor5-feature-suffix/src';
+
+import { default as name33 } from 'ckeditor5';
+import { default as name34 } from 'ckeditor5/src';
+import { default as name35 } from 'ckeditor5-feature';
+import { default as name36 } from 'ckeditor5-feature/src';
+import { default as name37 } from '@ckeditor/ckeditor5-featuresuffix';
+import { default as name38 } from '@ckeditor/ckeditor5-featuresuffix/src';
+import { default as name39 } from '@ckeditor/ckeditor5-feature-suffix';
+import { default as name40 } from '@ckeditor/ckeditor5-feature-suffix/src';
+
+import 'ckeditor5';
+import 'ckeditor5/src';
+import 'ckeditor5-feature';
+import 'ckeditor5-feature/src';
+import '@ckeditor/ckeditor5-featuresuffix';
+import '@ckeditor/ckeditor5-featuresuffix/src';
+import '@ckeditor/ckeditor5-feature-suffix';
+import '@ckeditor/ckeditor5-feature-suffix/src';
+
+export * from 'ckeditor5';
+export * from 'ckeditor5/src';
+export * from 'ckeditor5-feature';
+export * from 'ckeditor5-feature/src';
+export * from '@ckeditor/ckeditor5-featuresuffix';
+export * from '@ckeditor/ckeditor5-featuresuffix/src';
+export * from '@ckeditor/ckeditor5-feature-suffix';
+export * from '@ckeditor/ckeditor5-feature-suffix/src';
+
+export * as name41 from 'ckeditor5';
+export * as name42 from 'ckeditor5/src';
+export * as name43 from 'ckeditor5-feature';
+export * as name44 from 'ckeditor5-feature/src';
+export * as name45 from '@ckeditor/ckeditor5-featuresuffix';
+export * as name46 from '@ckeditor/ckeditor5-featuresuffix/src';
+export * as name47 from '@ckeditor/ckeditor5-feature-suffix';
+export * as name48 from '@ckeditor/ckeditor5-feature-suffix/src';
+
+export { name49 } from 'ckeditor5';
+export { name50 } from 'ckeditor5/src';
+export { name51 } from 'ckeditor5-feature';
+export { name52 } from 'ckeditor5-feature/src';
+export { name53 } from '@ckeditor/ckeditor5-featuresuffix';
+export { name54 } from '@ckeditor/ckeditor5-featuresuffix/src';
+export { name55 } from '@ckeditor/ckeditor5-feature-suffix';
+export { name56 } from '@ckeditor/ckeditor5-feature-suffix/src';
+
+export { name as name57 } from 'ckeditor5';
+export { name as name58 } from 'ckeditor5/src';
+export { name as name59 } from 'ckeditor5-feature';
+export { name as name60 } from 'ckeditor5-feature/src';
+export { name as name61 } from '@ckeditor/ckeditor5-featuresuffix';
+export { name as name62 } from '@ckeditor/ckeditor5-featuresuffix/src';
+export { name as name63 } from '@ckeditor/ckeditor5-feature-suffix';
+export { name as name64 } from '@ckeditor/ckeditor5-feature-suffix/src';
+
+export { default as name65 } from 'ckeditor5';
+export { default as name66 } from 'ckeditor5/src';
+export { default as name67 } from 'ckeditor5-feature';
+export { default as name68 } from 'ckeditor5-feature/src';
+export { default as name69 } from '@ckeditor/ckeditor5-featuresuffix';
+export { default as name70 } from '@ckeditor/ckeditor5-featuresuffix/src';
+export { default as name71 } from '@ckeditor/ckeditor5-feature-suffix';
+export { default as name72 } from '@ckeditor/ckeditor5-feature-suffix/src';

--- a/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-invalid-pkg/package.json
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-invalid-pkg/package.json
@@ -1,0 +1,1 @@
+This is invalid "package.json" file.

--- a/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-invalid-pkg/scoped-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-invalid-pkg/scoped-imports.js
@@ -1,0 +1,32 @@
+import name1 from '@ckeditor/ckeditor5-invalid-pkg';
+import name2 from '@ckeditor/ckeditor5-invalid-pkg/src';
+
+import * as name3 from '@ckeditor/ckeditor5-invalid-pkg';
+import * as name4 from '@ckeditor/ckeditor5-invalid-pkg/src';
+
+import { name5 } from '@ckeditor/ckeditor5-invalid-pkg';
+import { name6 } from '@ckeditor/ckeditor5-invalid-pkg/src';
+
+import { name as name7 } from '@ckeditor/ckeditor5-invalid-pkg';
+import { name as name8 } from '@ckeditor/ckeditor5-invalid-pkg/src';
+
+import { default as name9 } from '@ckeditor/ckeditor5-invalid-pkg';
+import { default as name10 } from '@ckeditor/ckeditor5-invalid-pkg/src';
+
+import '@ckeditor/ckeditor5-invalid-pkg';
+import '@ckeditor/ckeditor5-invalid-pkg/src';
+
+export * from '@ckeditor/ckeditor5-invalid-pkg';
+export * from '@ckeditor/ckeditor5-invalid-pkg/src';
+
+export * as name11 from '@ckeditor/ckeditor5-invalid-pkg';
+export * as name12 from '@ckeditor/ckeditor5-invalid-pkg/src';
+
+export { name13 } from '@ckeditor/ckeditor5-invalid-pkg';
+export { name14 } from '@ckeditor/ckeditor5-invalid-pkg/src';
+
+export { name as name15 } from '@ckeditor/ckeditor5-invalid-pkg';
+export { name as name16 } from '@ckeditor/ckeditor5-invalid-pkg/src';
+
+export { default as name17 } from '@ckeditor/ckeditor5-invalid-pkg';
+export { default as name18 } from '@ckeditor/ckeditor5-invalid-pkg/src';

--- a/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-missing-pkg/scoped-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/fixtures/no-scoped-imports-within-package/valid/packages/ckeditor5-missing-pkg/scoped-imports.js
@@ -1,0 +1,32 @@
+import name1 from '@ckeditor/ckeditor5-missing-pkg';
+import name2 from '@ckeditor/ckeditor5-missing-pkg/src';
+
+import * as name3 from '@ckeditor/ckeditor5-missing-pkg';
+import * as name4 from '@ckeditor/ckeditor5-missing-pkg/src';
+
+import { name5 } from '@ckeditor/ckeditor5-missing-pkg';
+import { name6 } from '@ckeditor/ckeditor5-missing-pkg/src';
+
+import { name as name7 } from '@ckeditor/ckeditor5-missing-pkg';
+import { name as name8 } from '@ckeditor/ckeditor5-missing-pkg/src';
+
+import { default as name9 } from '@ckeditor/ckeditor5-missing-pkg';
+import { default as name10 } from '@ckeditor/ckeditor5-missing-pkg/src';
+
+import '@ckeditor/ckeditor5-missing-pkg';
+import '@ckeditor/ckeditor5-missing-pkg/src';
+
+export * from '@ckeditor/ckeditor5-missing-pkg';
+export * from '@ckeditor/ckeditor5-missing-pkg/src';
+
+export * as name11 from '@ckeditor/ckeditor5-missing-pkg';
+export * as name12 from '@ckeditor/ckeditor5-missing-pkg/src';
+
+export { name13 } from '@ckeditor/ckeditor5-missing-pkg';
+export { name14 } from '@ckeditor/ckeditor5-missing-pkg/src';
+
+export { name as name15 } from '@ckeditor/ckeditor5-missing-pkg';
+export { name as name16 } from '@ckeditor/ckeditor5-missing-pkg/src';
+
+export { default as name17 } from '@ckeditor/ckeditor5-missing-pkg';
+export { default as name18 } from '@ckeditor/ckeditor5-missing-pkg/src';

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/allow-imports-only-from-main-package-entry-point.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/allow-imports-only-from-main-package-entry-point.js
@@ -8,7 +8,7 @@
 const RuleTester = require( 'eslint' ).RuleTester;
 
 const ruleTester = new RuleTester( {
-	parserOptions: { sourceType: 'module', ecmaVersion: 2018 }
+	parserOptions: { sourceType: 'module', ecmaVersion: 2020 }
 } );
 
 ruleTester.run(

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/ckeditor-error-messages.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/ckeditor-error-messages.js
@@ -15,7 +15,7 @@ const validJSDoc = '/**\n' +
 
 const validThrow = 'throw new CKEditorError( \'method-id-is-kebab\', this );\n';
 
-const ruleTester = new RuleTester( { parserOptions: { sourceType: 'module', ecmaVersion: 2018 } } );
+const ruleTester = new RuleTester( { parserOptions: { sourceType: 'module', ecmaVersion: 2020 } } );
 ruleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-error-message', require( '../../lib/rules/ckeditor-error-message' ), {
 	valid: [
 		validJSDoc + validThrow,

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/ckeditor-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/ckeditor-imports.js
@@ -24,7 +24,7 @@ const DLL_USE_FULL_NAME_IMPORT = {
 const ruleTester = new RuleTester( {
 	parserOptions: {
 		sourceType: 'module',
-		ecmaVersion: 2018
+		ecmaVersion: 2020
 	},
 	settings: {
 		dllPackages: [

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/license-header.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/license-header.js
@@ -26,7 +26,7 @@ const options = [ {
 const ruleTester = new RuleTester( {
 	parserOptions: {
 		sourceType: 'module',
-		ecmaVersion: 2018
+		ecmaVersion: 2020
 	}
 } );
 
@@ -38,85 +38,85 @@ const rule = require( '../../lib/rules/license-header' );
 ruleTester.run( ruleName, rule, {
 	valid: [ {
 		options,
-		code: fixtures.valid.header_and_whitespace
+		code: fixtures.valid.header_and_whitespace.content
 	}, {
 		options,
-		code: fixtures.valid.header_and_header_without_tag
+		code: fixtures.valid.header_and_header_without_tag.content
 	}, {
 		options,
-		code: fixtures.valid.header_and_line_comment_header
+		code: fixtures.valid.header_and_line_comment_header.content
 	}, {
 		options,
-		code: fixtures.valid.header_only
+		code: fixtures.valid.header_only.content
 	}, {
 		options,
-		code: fixtures.valid.header_with_code
+		code: fixtures.valid.header_with_code.content
 	}, {
 		options,
-		code: fixtures.valid.header_with_shebang_and_code
+		code: fixtures.valid.header_with_shebang_and_code.content
 	}, {
 		options,
-		code: fixtures.valid.header_with_shebang
+		code: fixtures.valid.header_with_shebang.content
 	} ],
 
 	invalid: [ {
 		options,
 		errors: [ incorrectWhitespaceBeforeError ],
-		code: fixtures.invalid.shebang_without_newline,
-		output: fixtures.valid.header_with_shebang_and_code
+		code: fixtures.invalid.shebang_without_newline.content,
+		output: fixtures.valid.header_with_shebang_and_code.content
 	}, {
 		options,
 		errors: [ incorrectWhitespaceBeforeError ],
-		code: fixtures.invalid.whitespace_before,
-		output: fixtures.valid.header_with_code
+		code: fixtures.invalid.whitespace_before.content,
+		output: fixtures.valid.header_with_code.content
 	}, {
 		options,
 		errors: [ incorrectWhitespaceBeforeError, incorrectWhitespaceAfterError ],
-		code: fixtures.invalid.whitespace_before_and_after,
-		output: fixtures.valid.header_with_code
+		code: fixtures.invalid.whitespace_before_and_after.content,
+		output: fixtures.valid.header_with_code.content
 	}, {
 		options,
 		errors: [ incorrectWhitespaceAfterError ],
-		code: fixtures.invalid.whitespace_after,
-		output: fixtures.valid.header_with_code
+		code: fixtures.invalid.whitespace_after.content,
+		output: fixtures.valid.header_with_code.content
 	}, {
 		options,
 		errors: [ incorrectHeaderError ],
-		code: fixtures.invalid.all_uppercase,
-		output: fixtures.valid.header_with_code
+		code: fixtures.invalid.all_uppercase.content,
+		output: fixtures.valid.header_with_code.content
 	}, {
 		options,
 		errors: [ missingHeaderError ],
-		code: fixtures.invalid.missing_tag,
-		output: fixtures.valid.header_and_header_without_tag
+		code: fixtures.invalid.missing_tag.content,
+		output: fixtures.valid.header_and_header_without_tag.content
 	}, {
 		options,
 		errors: [ missingHeaderError ],
-		code: fixtures.invalid.line_comment,
-		output: fixtures.valid.header_and_line_comment_header
+		code: fixtures.invalid.line_comment.content,
+		output: fixtures.valid.header_and_line_comment_header.content
 	}, {
 		options,
 		errors: [ missingHeaderError ],
-		code: fixtures.invalid.code_only,
-		output: fixtures.valid.header_with_code
+		code: fixtures.invalid.code_only.content,
+		output: fixtures.valid.header_with_code.content
 	}, {
 		options,
 		errors: [ missingHeaderError ],
 		code: '', // Empty file.
-		output: fixtures.valid.header_and_whitespace
+		output: fixtures.valid.header_and_whitespace.content
 	},
 	// Examples without fixers.
 	{
 		options,
 		errors: [ unexpectedContentBeforeError ],
-		code: fixtures.invalid.block_comment_before_license
+		code: fixtures.invalid.block_comment_before_license.content
 	}, {
 		options,
 		errors: [ unexpectedContentBeforeError ],
-		code: fixtures.invalid.code_between_shebang_and_header
+		code: fixtures.invalid.code_between_shebang_and_header.content
 	}, {
 		options,
 		errors: [ unexpectedContentBeforeError ],
-		code: fixtures.invalid.comment_between_shebang_and_header
+		code: fixtures.invalid.comment_between_shebang_and_header.content
 	} ]
 } );

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-build-extensions.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-build-extensions.js
@@ -9,7 +9,7 @@ const RuleTester = require( 'eslint' ).RuleTester;
 
 const importError = { message: 'Import that extends a CKEditor 5 build is not allowed.' };
 
-const ruleTester = new RuleTester( { parserOptions: { sourceType: 'module', ecmaVersion: 2018 } } );
+const ruleTester = new RuleTester( { parserOptions: { sourceType: 'module', ecmaVersion: 2020 } } );
 ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-build-extensions', require( '../../lib/rules/no-build-extensions' ), {
 	valid: [
 		// Importing an editor build.

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-cross-package-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-cross-package-imports.js
@@ -11,7 +11,7 @@ const RuleTester = require( 'eslint' ).RuleTester;
 const ruleTester = new RuleTester( {
 	parserOptions: {
 		sourceType: 'module',
-		ecmaVersion: 2018
+		ecmaVersion: 2020
 	}, settings: {
 		disallowedCrossImportsPackages: [
 			'ckeditor5-watchdog'

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-istanbul-in-debug-code.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-istanbul-in-debug-code.js
@@ -10,7 +10,7 @@ const RuleTester = require( 'eslint' ).RuleTester;
 const ruleTester = new RuleTester( {
 	parserOptions: {
 		sourceType: 'module',
-		ecmaVersion: 2018
+		ecmaVersion: 2020
 	}
 } );
 

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-relative-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-relative-imports.js
@@ -9,7 +9,7 @@ const RuleTester = require( 'eslint' ).RuleTester;
 
 const importError = { message: 'Imports of CKEditor5 packages shouldn\'t be relative.' };
 
-const ruleTester = new RuleTester( { parserOptions: { sourceType: 'module', ecmaVersion: 2018 } } );
+const ruleTester = new RuleTester( { parserOptions: { sourceType: 'module', ecmaVersion: 2020 } } );
 ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-relative-imports', require( '../../lib/rules/no-relative-imports' ), {
 	valid: [
 		'import Foo from \'../foo\';',

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-scoped-imports-within-package.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-scoped-imports-within-package.js
@@ -1,0 +1,94 @@
+/**
+ * @license Copyright (c) 2003-2023, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const RuleTester = require( 'eslint' ).RuleTester;
+const fixtureLoader = require( '../fixture-loader' );
+
+const errorMessage = 'Scoped import like "@ckeditor/*" to the same package where the import declaration is located is disallowed.';
+const errors = [
+	{ message: errorMessage, line: 1 },
+	{ message: errorMessage, line: 2 },
+	{ message: errorMessage, line: 4 },
+	{ message: errorMessage, line: 5 },
+	{ message: errorMessage, line: 7 },
+	{ message: errorMessage, line: 8 },
+	{ message: errorMessage, line: 10 },
+	{ message: errorMessage, line: 11 },
+	{ message: errorMessage, line: 13 },
+	{ message: errorMessage, line: 14 },
+	{ message: errorMessage, line: 16 },
+	{ message: errorMessage, line: 17 },
+	{ message: errorMessage, line: 19 },
+	{ message: errorMessage, line: 20 },
+	{ message: errorMessage, line: 22 },
+	{ message: errorMessage, line: 23 },
+	{ message: errorMessage, line: 25 },
+	{ message: errorMessage, line: 26 },
+	{ message: errorMessage, line: 28 },
+	{ message: errorMessage, line: 29 },
+	{ message: errorMessage, line: 31 },
+	{ message: errorMessage, line: 32 }
+];
+
+const ruleTester = new RuleTester( {
+	parserOptions: {
+		sourceType: 'module',
+		ecmaVersion: 2020
+	}
+} );
+
+const fixtures = fixtureLoader( 'no-scoped-imports-within-package' );
+
+const ruleName = 'eslint-plugin-ckeditor5-rules/no-scoped-imports-within-package';
+const rule = require( '../../lib/rules/no-scoped-imports-within-package' );
+
+ruleTester.run( ruleName, rule, {
+	valid: [
+		{
+			code: fixtures.valid.packages.ckeditor5_feature.no_scoped_imports.content,
+			filename: fixtures.valid.packages.ckeditor5_feature.no_scoped_imports.path
+		},
+		{
+			code: fixtures.valid.packages.ckeditor5_feature.scoped_imports_not_to_self.content,
+			filename: fixtures.valid.packages.ckeditor5_feature.scoped_imports_not_to_self.path
+		},
+		{
+			code: fixtures.valid.packages.ckeditor5_feature_nested.src.a.b.c.no_scoped_imports.content,
+			filename: fixtures.valid.packages.ckeditor5_feature_nested.src.a.b.c.no_scoped_imports.path
+		},
+		{
+			code: fixtures.valid.packages.ckeditor5_feature_nested.src.a.b.c.scoped_imports_not_to_self.content,
+			filename: fixtures.valid.packages.ckeditor5_feature_nested.src.a.b.c.scoped_imports_not_to_self.path
+		},
+		{
+			code: fixtures.valid.packages.ckeditor5_invalid_pkg.scoped_imports.content,
+			filename: fixtures.valid.packages.ckeditor5_invalid_pkg.scoped_imports.path
+		},
+		{
+			code: fixtures.valid.packages.ckeditor5_missing_pkg.scoped_imports.content,
+			filename: fixtures.valid.packages.ckeditor5_missing_pkg.scoped_imports.path
+		}
+	],
+
+	invalid: [
+		{
+			code: fixtures.invalid.packages.ckeditor5_feature.scoped_imports.content,
+			filename: fixtures.invalid.packages.ckeditor5_feature.scoped_imports.path,
+			errors
+		},
+		{
+			code: fixtures.invalid.packages.ckeditor5_feature_nested.src.a.b.c.scoped_imports.content,
+			filename: fixtures.invalid.packages.ckeditor5_feature_nested.src.a.b.c.scoped_imports.path,
+			errors
+		},
+		{
+			code: fixtures.invalid.packages.ckeditor5_feature_short.scoped_imports.content,
+			filename: fixtures.invalid.packages.ckeditor5_feature_short.scoped_imports.path,
+			errors
+		}
+	]
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (eslint-plugin-ckeditor5-rules): Created the `ckeditor5-rules/no-scoped-imports-within-package` that disallows using scoped import (like `"@ckeditor/ckeditor5-*"`) to the same package where the import declaration is located. Closes ckeditor/ckeditor5#14329.

Other (eslint-config-ckeditor5): Enabled the `ckeditor5-rules/no-scoped-imports-within-package` in the ESLint configuration.

Internal (eslint-config-ckeditor5): Bumped ESLint parser configuration to target the ES2020 grammar.

Internal (eslint-plugin-ckeditor5-rules): Aligned all tests for all ESLint rules to target the ES2020 grammar.

---

### Additional information

PR with documentation for the new rule: https://github.com/ckeditor/ckeditor5/pull/14358.

The CKEditor 5 code base is already fixed so that the `ckeditor5-rules/no-scoped-imports-within-package` does not report errors.
