### PR TITLE
Fix (eslint-plugin-ckeditor5-rules): Update `meta.docs.url` for recently introduced rules

### DIFF
--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-declare-module-only-in-augmentation-file.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-declare-module-only-in-augmentation-file.js
@@ -12,7 +12,7 @@ module.exports = {
 			description: 'Allow using module augmentation for "@ckeditor/ckeditor5-core" modules only in the "/src/augmentation.ts" files.',
 			category: 'CKEditor5',
 			// eslint-disable-next-line max-len
-			url: 'https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/code-style.html#declaring-module-augmentation-for-the-core-package-allow-declare-module-only-in-augmentation-file'
+			url: 'https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/code-style.html#declaring-module-augmentation-for-the-core-package-ckeditor5-rulesallow-declare-module-only-in-augmentation-file'
 		}
 	},
 	create( context ) {

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-imports-only-from-main-package-entry-point.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-imports-only-from-main-package-entry-point.js
@@ -12,7 +12,7 @@ module.exports = {
 			description: 'Allow importing from "@ckeditor/*" modules only from the main package entry point.',
 			category: 'CKEditor5',
 			// eslint-disable-next-line max-len
-			url: 'https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/code-style.html#importing-from-modules-allow-imports-only-from-main-package-entry-point'
+			url: 'https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/code-style.html#importing-from-modules-ckeditor5-rulesallow-imports-only-from-main-package-entry-point'
 		},
 		schema: []
 	},

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/require-as-const-returns-in-methods.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/require-as-const-returns-in-methods.js
@@ -12,7 +12,7 @@ module.exports = {
 			description: 'Require the use of "as const" in all return statements for methods with given names.',
 			category: 'CKEditor5',
 			// eslint-disable-next-line max-len
-			url: 'https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/code-style.html#require-as-const-require-as-const-returns-in-methods'
+			url: 'https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/code-style.html#require-as-const-ckeditor5-rulesrequire-as-const-returns-in-methods'
 		},
 		schema: [
 			{


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal (eslint-plugin-ckeditor5-rules): Updated `meta.docs.url` for recently introduced rules: `ckeditor5-rules/allow-declare-module-only-in-augmentation-file`, `ckeditor5-rules/allow-imports-only-from-main-package-entry-point` and `ckeditor5-rules/require-as-const-returns-in-methods`. See [#13434](https://github.com/ckeditor/ckeditor5/issues/13434) and [#14340](https://github.com/ckeditor/ckeditor5/pull/14340).

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
