### PR TITLE
Node version bump

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "reinstall": "yarn run clean && yarn install"
   },
   "engines": {
-    "node": ">=14.0.0"
+    "node": ">=18.0.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Other: Updated the required version of Node.js to 18 when developing the repository. See ckeditor/ckeditor5#14924.