### PR TITLE
Upgrade to the latest version "@es-joy/jsdoccomment"

### DIFF
--- a/packages/eslint-plugin-ckeditor5-rules/package.json
+++ b/packages/eslint-plugin-ckeditor5-rules/package.json
@@ -37,7 +37,7 @@
     "eslint": ">=7.0.0"
   },
   "dependencies": {
-    "@es-joy/jsdoccomment": "^0.36.1",
+    "@es-joy/jsdoccomment": "^0.40.1",
     "@typescript-eslint/parser": "^5.52.0",
     "fs-extra": "^11.1.1",
     "upath": "^2.0.1"


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (eslint-plugin-ckeditor5-rules): Upgrade the `@es-joy/jsdoccomment` package to its latest version to make the CKEditor 5 compatible with Node@20. Closes ckeditor/ckeditor5#15203.
