### PR TITLE
Fixed augmentation rule on Windows OS

### DIFF
--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-declare-module-only-in-augmentation-file.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-declare-module-only-in-augmentation-file.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+const upath = require( 'upath' );
+
 module.exports = {
 	meta: {
 		type: 'problem',
@@ -23,7 +25,9 @@ module.exports = {
 					return;
 				}
 
-				if ( context.getFilename().endsWith( '/src/augmentation.ts' ) ) {
+				const normalizedPath = upath.toUnix( context.getFilename() );
+
+				if ( normalizedPath.endsWith( '/src/augmentation.ts' ) ) {
 					// Skip if module declaration is already in the specified file.
 					return;
 				}

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/allow-declare-module-only-in-augmentation-file.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/allow-declare-module-only-in-augmentation-file.js
@@ -19,6 +19,10 @@ ruleTester.run(
 			{
 				code: 'declare module "@ckeditor/ckeditor5-core" {}',
 				filename: '/some/path/src/augmentation.ts'
+			},
+			{
+				code: 'declare module "@ckeditor/ckeditor5-core" {}',
+				filename: 'C:\\some\\path\\src\\augmentation.ts'
 			}
 		],
 		invalid: [


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (eslint-plugin-ckeditor5-rules): Fixed `ckeditor5-rules/allow-declare-module-only-in-augmentation-file` rule that did not detect the correct path to the augmentation file on Windows due to the use of different path separators. Closes ckeditor/ckeditor5#15426.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
