### PR TITLE
Feat: Add rule requiring file extensions in exports

### DIFF
--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/require-file-extensions-in-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/require-file-extensions-in-imports.js
@@ -30,7 +30,7 @@ module.exports = {
 		},
 		fixable: 'code',
 		messages: {
-			'missingFileExtension': 'Missing file extension in import "{{ url }}"'
+			'missingFileExtension': 'Missing file extension in import/export "{{ url }}"'
 		},
 		schema: [
 			{
@@ -54,89 +54,97 @@ module.exports = {
 			...options
 		} );
 
-		return {
-			ImportDeclaration( node ) {
-				const url = node.source.value;
-
-				if ( extname( url ) ) {
-					// URL already includes file extension.
-					return;
-				}
-
-				if ( isBuiltin( url ) ) {
-					// URL is native Node.js module, e.g. `fs` or `path`.
-					return;
-				}
-
-				if ( packageFullPattern.test( url ) ) {
-					// URL is third-party dependency, e.g. `lodash-es`
-					return;
-				}
-
-				try {
-					/**
-					 * Below, "path" refers to the absolute path to the file in the file system (e.g. `/absolute/path/to/file.js`)
-					 * and "URL" refers to the path used in the import (e.g. `./some/path` or `@scope/package`).
-					 */
-
-					// Resolve URL to absolute filesystem path.
-					const resolvedPath = resolver( dirname( context.getFilename() ), url );
-
-					// Turn `/absolute/path/to/file.js` into `[ 'absolute', 'path', 'to', 'file' ]`.
-					const { dir: pathDir, name: pathName, ext: pathExt } = parse( resolvedPath );
-					const { dir: urlDir, name: urlName } = parse( url );
-					const resolvedPathParts = pathDir.split( sep ).concat( pathName );
-					const urlParts = urlDir.split( sep ).concat( urlName );
-
-					/**
-					 * Find the last matching parts between the relative and absolute paths. Example:
-					 *  - `/absolute/path/to/file.js` and `../to/file`
-					 *                       ^^^^                ^^^^
-					 *
-					 * - `/absolute/path/to/index.js` and `../to`
-					 *                   ^^                   ^^
-					 */
-					const lastMatchingIndex = resolvedPathParts.findLastIndex( element => urlParts.includes( element ) );
-
-					/**
-					 * Concatenate parts of the path (after the `lastMatchingIndex`) to the end of the URL. Example:
-					 *
-					 * - Path: `/absolute/path/to/index.js`
-					 * - URL: `../to`
-					 * - Result: `../to/index` (no extension)
-					 */
-					const filePath = urlParts
-						.concat( resolvedPathParts.slice( lastMatchingIndex + 1 ) )
-						.join( sep );
-
-					// Get the original quoting style from the source code (" or ').
-					const quoteStyle = node.source.raw[ 0 ];
-
-					// Get the final file extension, prioritizing overrides.
-					const extension = extensionsOverride[ pathExt ] || pathExt;
-
-					// Issue can be automatically fixed.
-					context.report( {
-						node,
-						messageId: 'missingFileExtension',
-						data: {
-							url
-						},
-						fix( fixer ) {
-							return fixer.replaceText( node.source, quoteStyle + filePath + extension + quoteStyle );
-						}
-					} );
-				} catch {
-					// Automatic fix is not possible. Report a problem that needs to be fixed manually.
-					context.report( {
-						node,
-						messageId: 'missingFileExtension',
-						data: {
-							url
-						}
-					} );
-				}
+		function validatePath( node ) {
+			if ( !node.source ) {
+				return;
 			}
+
+			const url = node.source.value;
+
+			if ( extname( url ) ) {
+				// URL already includes file extension.
+				return;
+			}
+
+			if ( isBuiltin( url ) ) {
+				// URL is native Node.js module, e.g. `fs` or `path`.
+				return;
+			}
+
+			if ( packageFullPattern.test( url ) ) {
+				// URL is third-party dependency, e.g. `lodash-es`
+				return;
+			}
+
+			try {
+				/**
+				 * Below, "path" refers to the absolute path to the file in the file system (e.g. `/absolute/path/to/file.js`)
+				 * and "URL" refers to the path used in the import (e.g. `./some/path` or `@scope/package`).
+				 */
+
+				// Resolve URL to absolute filesystem path.
+				const resolvedPath = resolver( dirname( context.getFilename() ), url );
+
+				// Turn `/absolute/path/to/file.js` into `[ 'absolute', 'path', 'to', 'file' ]`.
+				const { dir: pathDir, name: pathName, ext: pathExt } = parse( resolvedPath );
+				const { dir: urlDir, name: urlName } = parse( url );
+				const resolvedPathParts = pathDir.split( sep ).concat( pathName );
+				const urlParts = urlDir.split( sep ).concat( urlName );
+
+				/**
+				 * Find the last matching parts between the relative and absolute paths. Example:
+				 *  - `/absolute/path/to/file.js` and `../to/file`
+				 *                       ^^^^                ^^^^
+				 *
+				 * - `/absolute/path/to/index.js` and `../to`
+				 *                   ^^                   ^^
+				 */
+				const lastMatchingIndex = resolvedPathParts.findLastIndex( element => urlParts.includes( element ) );
+
+				/**
+				 * Concatenate parts of the path (after the `lastMatchingIndex`) to the end of the URL. Example:
+				 *
+				 * - Path: `/absolute/path/to/index.js`
+				 * - URL: `../to`
+				 * - Result: `../to/index` (no extension)
+				 */
+				const filePath = urlParts
+					.concat( resolvedPathParts.slice( lastMatchingIndex + 1 ) )
+					.join( sep );
+
+				// Get the original quoting style from the source code (" or ').
+				const quoteStyle = node.source.raw[ 0 ];
+
+				// Get the final file extension, prioritizing overrides.
+				const extension = extensionsOverride[ pathExt ] || pathExt;
+
+				// Issue can be automatically fixed.
+				context.report( {
+					node,
+					messageId: 'missingFileExtension',
+					data: {
+						url
+					},
+					fix( fixer ) {
+						return fixer.replaceText( node.source, quoteStyle + filePath + extension + quoteStyle );
+					}
+				} );
+			} catch {
+				// Automatic fix is not possible. Report a problem that needs to be fixed manually.
+				context.report( {
+					node,
+					messageId: 'missingFileExtension',
+					data: {
+						url
+					}
+				} );
+			}
+		}
+
+		return {
+			ImportDeclaration: validatePath,
+			ExportAllDeclaration: validatePath,
+			ExportNamedDeclaration: validatePath
 		};
 	}
 };

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/require-file-extensions-in-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/require-file-extensions-in-imports.js
@@ -13,6 +13,8 @@ const ruleTester = new RuleTester( {
 
 ruleTester.run( 'require-file-extensions-in-imports', require( '../../lib/rules/require-file-extensions-in-imports' ), {
 	valid: [
+
+		// Import
 		{
 			code: 'import Something from "/absolute/path/with/file.extension";'
 		},
@@ -30,31 +32,125 @@ ruleTester.run( 'require-file-extensions-in-imports', require( '../../lib/rules/
 		},
 		{
 			code: 'import Something from "node:fs";'
+		},
+
+		// Export all
+		{
+			code: 'export * as Something from "/absolute/path/with/file.extension";'
+		},
+		{
+			code: 'export * as Something from "./relative/path/with/file.extension";'
+		},
+		{
+			code: 'export * as Something from "library";'
+		},
+		{
+			code: 'export * as Something from "@scoped/library";'
+		},
+		{
+			code: 'export * as Something from "fs";'
+		},
+		{
+			code: 'export * as Something from "node:fs";'
+		},
+
+		// Named export
+		{
+			code: 'export { Something } from "/absolute/path/with/file.extension";'
+		},
+		{
+			code: 'export { Something } from "./relative/path/with/file.extension";'
+		},
+		{
+			code: 'export { Something } from "library";'
+		},
+		{
+			code: 'export { Something } from "@scoped/library";'
+		},
+		{
+			code: 'export { Something } from "fs";'
+		},
+		{
+			code: 'export { Something } from "node:fs";'
 		}
 	],
 	invalid: [
+
+		// Import
 		{
 			code: 'import Something from "/absolute/path/without/file/extension";',
 			errors: [
-				'Missing file extension in import "/absolute/path/without/file/extension"'
+				'Missing file extension in import/export "/absolute/path/without/file/extension"'
 			]
 		},
 		{
 			code: 'import Something from "./relative/path/without/file/extension";',
 			errors: [
-				'Missing file extension in import "./relative/path/without/file/extension"'
+				'Missing file extension in import/export "./relative/path/without/file/extension"'
 			]
 		},
 		{
 			code: 'import Something from "library/path/without/file/extension";',
 			errors: [
-				'Missing file extension in import "library/path/without/file/extension"'
+				'Missing file extension in import/export "library/path/without/file/extension"'
 			]
 		},
 		{
 			code: 'import Something from "@scoped/library/path/without/file/extension";',
 			errors: [
-				'Missing file extension in import "@scoped/library/path/without/file/extension"'
+				'Missing file extension in import/export "@scoped/library/path/without/file/extension"'
+			]
+		},
+
+		// Export all
+		{
+			code: 'export * as Something from "/absolute/path/without/file/extension";',
+			errors: [
+				'Missing file extension in import/export "/absolute/path/without/file/extension"'
+			]
+		},
+		{
+			code: 'export * as Something from "./relative/path/without/file/extension";',
+			errors: [
+				'Missing file extension in import/export "./relative/path/without/file/extension"'
+			]
+		},
+		{
+			code: 'export * as Something from "library/path/without/file/extension";',
+			errors: [
+				'Missing file extension in import/export "library/path/without/file/extension"'
+			]
+		},
+		{
+			code: 'export * as Something from "@scoped/library/path/without/file/extension";',
+			errors: [
+				'Missing file extension in import/export "@scoped/library/path/without/file/extension"'
+			]
+		},
+
+		// Named export
+		{
+			code: 'export { Something } from "/absolute/path/without/file/extension";',
+			errors: [
+				'Missing file extension in import/export "/absolute/path/without/file/extension"'
+			]
+		},
+		{
+			code: 'export { Something } from "./relative/path/without/file/extension";',
+			errors: [
+				'Missing file extension in import/export "./relative/path/without/file/extension"'
+			]
+		},
+		{
+			code: 'export { Something } from "library/path/without/file/extension";',
+			errors: [
+				'Missing file extension in import/export "library/path/without/file/extension"'
+			]
+		},
+		{
+			code: 'export { Something } from "@scoped/library/path/without/file/extension";',
+			errors: [
+				'Missing file extension in import/export "@scoped/library/path/without/file/extension"'
 			]
 		}
 	]


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other (eslint-plugin-ckeditor5-rules): Improved the `ckeditor5-rules/require-file-extensions-in-imports` to require a file extension in both imports and exports. See https://github.com/ckeditor/ckeditor5/issues/13673.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
