### PR TITLE
Add new rule to enforce correct imports of the SVG icons

### DIFF
--- a/packages/eslint-plugin-ckeditor5-rules/lib/index.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/index.js
@@ -10,6 +10,7 @@ module.exports = {
 		'no-relative-imports': require( './rules/no-relative-imports' ),
 		'ckeditor-error-message': require( './rules/ckeditor-error-message' ),
 		'ckeditor-imports': require( './rules/ckeditor-imports' ),
+		'no-cross-package-svg-imports': require( './rules/no-cross-package-svg-imports' ),
 		'no-cross-package-imports': require( './rules/no-cross-package-imports' ),
 		'no-scoped-imports-within-package': require( './rules/no-scoped-imports-within-package' ),
 		'license-header': require( './rules/license-header' ),

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-cross-package-svg-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-cross-package-svg-imports.js
@@ -1,0 +1,60 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const { extname, sep } = require( 'upath' );
+
+module.exports = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Disallow direct imports of SVG icons from other packages',
+			category: 'CKEditor5',
+			// eslint-disable-next-line max-len
+			url: 'https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/code-style.html#importing-svg-files-from-other-packages-ckeditor5-rulesno-cross-package-svg-imports'
+		}
+	},
+	create( context ) {
+		return {
+			ImportDeclaration( node ) {
+				const url = node.source.value;
+
+				if ( extname( url ) !== '.svg' ) {
+					return;
+				}
+
+				// Turn `../theme/icons/check.svg` into `[ '..', 'theme', 'icons', 'check.svg' ]`.
+				const parts = url.split( sep );
+
+				// Get index of the part of the URL containing `theme`.
+				const themeIndex = parts.findIndex( part => part === 'theme' );
+
+				/**
+				 * Check if `theme` index was found and if the previous part of the URL starts with a dot. This
+				 * is to prevent people from working around this rule by replacing `OTHER_PACKAGE/theme/icons/icon.svg`
+				 * to equivalent but relative path like `../../OTHER_PACKAGE/theme/icons/icon.svg`.
+				 *
+				 * Correct import from within the same package:
+				 * - `../theme/icons/icon.svg`.
+				 *
+				 * Incorrect imports from other packages:
+				 * - `OTHER_PACKAGE/theme/icons/icon.svg`.
+				 * - `../../../OTHER_PACKAGE/theme/icons/icon.svg`.
+				 * - `../../../../../nod_modules/OTHER_PACKAGE/theme/icons/icon.svg`.
+				 */
+				if ( themeIndex >= 0 && parts[ themeIndex - 1 ].startsWith( '.' ) ) {
+					return;
+				}
+
+				context.report( {
+					node,
+					// eslint-disable-next-line max-len
+					message: 'Icons can only be imported from package\'s own `theme` folder or by importing it from other package main entrypoint.'
+				} );
+			}
+		};
+	}
+};

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-cross-package-svg-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-cross-package-svg-imports.js
@@ -33,9 +33,9 @@ module.exports = {
 				const themeIndex = parts.findIndex( part => part === 'theme' );
 
 				/**
-				 * Check if `theme` index was found and if the previous part of the URL starts with a dot. This
-				 * is to prevent people from working around this rule by replacing `OTHER_PACKAGE/theme/icons/icon.svg`
-				 * to equivalent but relative path like `../../OTHER_PACKAGE/theme/icons/icon.svg`.
+				 * Check if `theme` index was found and if the previous part of the URL is `..`. This is done to
+				 * prevent working around this rule by replacing `OTHER_PACKAGE/theme/icons/icon.svg` to
+				 * equivalent but relative path like `../../OTHER_PACKAGE/theme/icons/icon.svg`.
 				 *
 				 * Correct import from within the same package:
 				 * - `../theme/icons/icon.svg`.
@@ -45,7 +45,7 @@ module.exports = {
 				 * - `../../../OTHER_PACKAGE/theme/icons/icon.svg`.
 				 * - `../../../../../nod_modules/OTHER_PACKAGE/theme/icons/icon.svg`.
 				 */
-				if ( themeIndex >= 0 && parts[ themeIndex - 1 ].startsWith( '.' ) ) {
+				if ( themeIndex >= 0 && parts[ themeIndex - 1 ] === ( '..' ) ) {
 					return;
 				}
 

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-cross-package-svg-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-cross-package-svg-imports.js
@@ -1,0 +1,43 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const RuleTester = require( 'eslint' ).RuleTester;
+
+const ruleTester = new RuleTester( {
+	parser: require.resolve( '@typescript-eslint/parser' )
+} );
+
+ruleTester.run( 'no-cross-package-svg-imports', require( '../../lib/rules/no-cross-package-svg-imports' ), {
+	valid: [
+		{
+			code: 'import Something from "../theme/icons/icon.svg";'
+		},
+		{
+			code: 'import Something from "../../theme/icons/icon.svg";'
+		}
+	],
+	invalid: [
+		{
+			code: 'import Something from "OTHER_PACKAGE/theme/icons/icon.svg";',
+			errors: [
+				'Icons can only be imported from package\'s own `theme` folder or by importing it from other package main entrypoint.'
+			]
+		},
+		{
+			code: 'import Something from "../../../OTHER_PACKAGE/theme/icons/icon.svg";',
+			errors: [
+				'Icons can only be imported from package\'s own `theme` folder or by importing it from other package main entrypoint.'
+			]
+		},
+		{
+			code: 'import Something from "../../../../../nod_modules/OTHER_PACKAGE/theme/icons/icon.svg";',
+			errors: [
+				'Icons can only be imported from package\'s own `theme` folder or by importing it from other package main entrypoint.'
+			]
+		}
+	]
+} );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (eslint-plugin-ckeditor5-rules): Add a rule to enforce correct imports of the SVG icons. See ckeditor/ckeditor5#15704.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
