### PR TITLE
Improve validation of the file extensions in imports/exports

### DIFF
--- a/packages/eslint-plugin-ckeditor5-rules/package.json
+++ b/packages/eslint-plugin-ckeditor5-rules/package.json
@@ -41,6 +41,8 @@
     "@typescript-eslint/parser": "^5.52.0",
     "enhanced-resolve": "^5.15.0",
     "fs-extra": "^11.1.1",
-    "upath": "^2.0.1"
+    "resolve.exports": "^2.0.2",
+    "upath": "^2.0.1",
+    "validate-npm-package-name": "^5.0.0"
   }
 }

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/require-file-extensions-in-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/require-file-extensions-in-imports.js
@@ -22,16 +22,23 @@ ruleTester.run( 'require-file-extensions-in-imports', require( '../../lib/rules/
 			code: 'import Something from "./relative/path/with/file.extension";'
 		},
 		{
-			code: 'import Something from "library";'
-		},
-		{
-			code: 'import Something from "@scoped/library";'
-		},
-		{
 			code: 'import Something from "fs";'
 		},
 		{
 			code: 'import Something from "node:fs";'
+		},
+
+		// Import external dependency
+		{
+			code: 'import Something from "enhanced-resolve";' // Unscoped
+		},
+		{
+			code: 'import Something from "@ckeditor/ckeditor5-dev-utils";' // Scoped
+		},
+
+		// Import from external dependency that uses "exports" field
+		{
+			code: 'import tokenizer from "postcss/lib/tokenize";'
 		},
 
 		// Export all
@@ -42,10 +49,10 @@ ruleTester.run( 'require-file-extensions-in-imports', require( '../../lib/rules/
 			code: 'export * as Something from "./relative/path/with/file.extension";'
 		},
 		{
-			code: 'export * as Something from "library";'
+			code: 'export * as Something from "enhanced-resolve";'
 		},
 		{
-			code: 'export * as Something from "@scoped/library";'
+			code: 'export * as Something from "@ckeditor/ckeditor5-dev-utils";'
 		},
 		{
 			code: 'export * as Something from "fs";'
@@ -62,10 +69,10 @@ ruleTester.run( 'require-file-extensions-in-imports', require( '../../lib/rules/
 			code: 'export { Something } from "./relative/path/with/file.extension";'
 		},
 		{
-			code: 'export { Something } from "library";'
+			code: 'export { Something } from "enhanced-resolve";'
 		},
 		{
-			code: 'export { Something } from "@scoped/library";'
+			code: 'export { Something } from "@ckeditor/ckeditor5-dev-utils";'
 		},
 		{
 			code: 'export { Something } from "fs";'
@@ -90,15 +97,16 @@ ruleTester.run( 'require-file-extensions-in-imports', require( '../../lib/rules/
 			]
 		},
 		{
-			code: 'import Something from "library/path/without/file/extension";',
+			code: 'import Something from "@ckeditor/ckeditor5-dev-utils/lib/index";',
 			errors: [
-				'Missing file extension in import/export "library/path/without/file/extension"'
+				'Missing file extension in import/export "@ckeditor/ckeditor5-dev-utils/lib/index"'
 			]
 		},
 		{
-			code: 'import Something from "@scoped/library/path/without/file/extension";',
+			code: 'import Something from ".";',
+			output: 'import Something from "./lib/index.js";',
 			errors: [
-				'Missing file extension in import/export "@scoped/library/path/without/file/extension"'
+				'Missing file extension in import/export "."'
 			]
 		},
 
@@ -115,16 +123,18 @@ ruleTester.run( 'require-file-extensions-in-imports', require( '../../lib/rules/
 				'Missing file extension in import/export "./relative/path/without/file/extension"'
 			]
 		},
+
+		// Export all from external library without file extension.
 		{
-			code: 'export * as Something from "library/path/without/file/extension";',
+			code: 'export * as Something from "enhanced-resolve/lib/index";',
 			errors: [
-				'Missing file extension in import/export "library/path/without/file/extension"'
+				'Missing file extension in import/export "enhanced-resolve/lib/index"'
 			]
 		},
 		{
-			code: 'export * as Something from "@scoped/library/path/without/file/extension";',
+			code: 'export * as Something from "@ckeditor/ckeditor5-dev-utils/lib/index";',
 			errors: [
-				'Missing file extension in import/export "@scoped/library/path/without/file/extension"'
+				'Missing file extension in import/export "@ckeditor/ckeditor5-dev-utils/lib/index"'
 			]
 		},
 
@@ -141,16 +151,18 @@ ruleTester.run( 'require-file-extensions-in-imports', require( '../../lib/rules/
 				'Missing file extension in import/export "./relative/path/without/file/extension"'
 			]
 		},
+
+		// Named export from external library without file extension.
 		{
-			code: 'export { Something } from "library/path/without/file/extension";',
+			code: 'export { ResolverFactory } from "enhanced-resolve/lib/index";',
 			errors: [
-				'Missing file extension in import/export "library/path/without/file/extension"'
+				'Missing file extension in import/export "enhanced-resolve/lib/index"'
 			]
 		},
 		{
-			code: 'export { Something } from "@scoped/library/path/without/file/extension";',
+			code: 'export { git } from "@ckeditor/ckeditor5-dev-utils/lib/index";',
 			errors: [
-				'Missing file extension in import/export "@scoped/library/path/without/file/extension"'
+				'Missing file extension in import/export "@ckeditor/ckeditor5-dev-utils/lib/index"'
 			]
 		}
 	]


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (eslint-plugin-ckeditor5-rules): Report a missing file extension when '.' import or export is used. Fixes [#15880](https://github.com/ckeditor/ckeditor5/issues/15880).

Fix (eslint-plugin-ckeditor5-rules): Properly detect valid imports of dependencies using the `exports` field.

---

### Additional information

The first fix results in a problem being reported when using `.` import or export. Previously, this was incorrectly recognized as a valid name of an external dependency.

The second fix ensures that the rule won't report a problem with valid imports of dependencies using the `exports` field in their `package.json` file. Examples:

* https://github.com/ckeditor/ckeditor5/blob/a5b65112c56e9c993c78372c57c9232e0cc1941e/docs/_snippets/framework/tutorials/using-react-in-widget.js#L12-L13
* https://github.com/ckeditor/ckeditor5/blob/a5b65112c56e9c993c78372c57c9232e0cc1941e/packages/ckeditor5-ui/src/colorpicker/colorpickerview.ts#L21-L22
