### PR TITLE
Improve autofix for `'.'` imports

### DIFF
--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/require-file-extensions-in-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/require-file-extensions-in-imports.js
@@ -94,8 +94,13 @@ module.exports = {
 				 *
 				 * - `/absolute/path/to/index.js` and `../to`
 				 *                   ^^                   ^^
+				 *
+				 * - `/absolute/path/to/index.js and `.`
+				 *                   ^^               ^
 				 */
-				const lastMatchingIndex = resolvedPathParts.findLastIndex( element => urlParts.includes( element ) );
+				const lastMatchingIndex = resolvedPathParts.at( -1 ) === urlParts.at( -1 ) ?
+					resolvedPathParts.length - 1 : // Get index containing file name
+					resolvedPathParts.length - 2; // Get index containing directory name
 
 				/**
 				 * Concatenate parts of the path (after the `lastMatchingIndex`) to the end of the URL. Example:

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/require-file-extensions-in-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/require-file-extensions-in-imports.js
@@ -104,7 +104,7 @@ ruleTester.run( 'require-file-extensions-in-imports', require( '../../lib/rules/
 		},
 		{
 			code: 'import Something from ".";',
-			output: 'import Something from "./lib/index.js";',
+			output: 'import Something from "./index.js";',
 			errors: [
 				'Missing file extension in import/export "."'
 			]


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Fix (eslint-plugin-ckeditor5-rules): Improve autofixer for `'.'` imports to prepare a relative path to the `index.js` file rather than an absolute path to the imported file. Closes ckeditor/ckeditor5#15880.

---

### Additional information

In #31 we introduced a fix that makes the rule correctly report `'.'` imports as invalid because they do not contain the path to the specific file and file extension. This works fine, but if such an import exists, autofixer doesn't update it to `./index.js' (as it should), but to the absolute path of the file, which is nonsense. This PR fixes the autofixer so that the rule can properly fix this problem by itself.
