### PR TITLE
Upgraded ckeditor5-dev-* to the latest major version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,9 +29,9 @@
     "url": "https://github.com/ckeditor/ckeditor5-linters-config.git"
   },
   "devDependencies": {
-    "@ckeditor/ckeditor5-dev-bump-year": "^41.0.0",
-    "@ckeditor/ckeditor5-dev-ci": "^41.0.0",
-    "@ckeditor/ckeditor5-dev-release-tools": "^41.0.0",
+    "@ckeditor/ckeditor5-dev-bump-year": "^42.0.0",
+    "@ckeditor/ckeditor5-dev-ci": "^42.0.0",
+    "@ckeditor/ckeditor5-dev-release-tools": "^42.0.0",
     "eslint": "^7.0.0",
     "husky": "^8.0.2",
     "lint-staged": "^13.0.0",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Upgraded ckeditor5-dev-* to the latest major version.

---

### Additional information

This repository can be cloned inside the `external/` directory in the CKEditor 5 environment. To avoid package duplications, let's use the same version as CKE5.
