### PR TITLE
Fixed `parsearguments()` function throwing error when the number of c…

### DIFF
--- a/scripts/utils/parsearguments.js
+++ b/scripts/utils/parsearguments.js
@@ -33,7 +33,7 @@ module.exports = function parseArguments( cliArguments ) {
 		],
 
 		default: {
-			concurrency: require( 'os' ).cpus().length / 2,
+			concurrency: Math.floor( require( 'os' ).cpus().length / 2 ) || 1,
 			packages: null,
 			ci: false,
 			verbose: false,


### PR DESCRIPTION
…ores is odd.

### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Fixed `executeInParallel()` function throwing error when the number of cores is odd. See ckeditor/ckeditor5#17025.

---

### Additional information

*For example – encountered issues, assumptions you had to make, other affected tickets, etc.*
