### PR TITLE
Add `ckeditor5/ckeditor-plugin-flags` rule

### DIFF
--- a/packages/eslint-config-ckeditor5/.eslintrc.js
+++ b/packages/eslint-config-ckeditor5/.eslintrc.js
@@ -483,6 +483,12 @@ module.exports = {
 					{
 						methodNames: METHODS_THAT_USE_AS_CONST_INSTEAD_OF_RETURN_TYPE
 					}
+				],
+				'ckeditor5-rules/ckeditor-plugin-flags': [
+					'error',
+					{
+						disallowedFlags: [ 'isOfficialPlugin', 'isPremiumPlugin' ]
+					}
 				]
 			}
 		},

--- a/packages/eslint-plugin-ckeditor5-rules/lib/index.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/index.js
@@ -11,6 +11,7 @@ module.exports = {
 		'no-relative-imports': require( './rules/no-relative-imports' ),
 		'ckeditor-error-message': require( './rules/ckeditor-error-message' ),
 		'ckeditor-imports': require( './rules/ckeditor-imports' ),
+		'ckeditor-plugin-flags': require( './rules/ckeditor-plugin-flags.js' ),
 		'no-cross-package-imports': require( './rules/no-cross-package-imports' ),
 		'no-scoped-imports-within-package': require( './rules/no-scoped-imports-within-package' ),
 		'license-header': require( './rules/license-header' ),

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/ckeditor-plugin-flags.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/ckeditor-plugin-flags.js
@@ -1,0 +1,598 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const PLUGIN_NAME_METHOD_NAME = 'pluginName';
+
+module.exports = {
+	meta: {
+		type: 'problem',
+		fixable: 'code',
+		docs: {
+			description: 'Enforce the presence of the plugin flags.',
+			category: 'CKEditor5'
+		},
+		schema: [
+			{
+				type: 'object',
+				properties: {
+					requiredFlags: {
+						type: 'array',
+						items: {
+							type: 'object',
+							properties: {
+								name: { type: 'string' },
+								returnValue: { type: 'boolean' }
+							},
+							required: [ 'name', 'returnValue' ]
+						},
+						optional: true
+					},
+					disallowedFlags: {
+						type: 'array',
+						items: {
+							type: 'string'
+						},
+						optional: true
+					}
+				},
+				additionalProperties: false
+			}
+		],
+		messages: {
+			disallowedFlag: 'The class member \'{{flag}}\' is disallowed here and should be removed.',
+			missingRequiredFlag: 'The class should have a static getter method \'{{flag}}\' that returns {{returnValue}}.',
+			incorrectReturnValue: 'The method \'{{flag}}\' should return {{returnValue}} but returns {{actualValue}} instead.',
+			incorrectReturnLiteral: 'The method \'{{flag}}\' should return a literal value with the {{returnValue}} value.',
+			notPublicGetter: 'The method \'{{flag}}\' should be defined as a public getter method.',
+			singleReturnStatement: 'The method \'{{flag}}\' should have a single return statement.',
+			definedBeforePluginName: 'The method \'{{flag}}\' should be defined after the \'pluginName\' method.',
+			definedInProperOrder: 'The method \'{{flag}}\' should be defined directly after other flag method.',
+			definedAfterSpecificMethod: 'The method \'{{flag}}\' should be defined after the \'{{before}}\' method.'
+		}
+	},
+
+	create( context ) {
+		if ( !getRequiredFlagsConfig( context ).length && !getDisallowedFlagsConfig( context ).length ) {
+			return {};
+		}
+
+		return {
+			'ClassDeclaration:exit'( classDeclaration ) {
+				if ( isPluginClassDeclaration( classDeclaration ) ) {
+					analyzePluginClass( context, classDeclaration );
+				}
+			}
+		};
+	}
+};
+
+/**
+ * Returns the required flags from the rule options.
+ *
+ * @param {Object} context The ESLint rule context.
+ * @returns {Array.<Object>}
+ */
+function getRequiredFlagsConfig( context ) {
+	return context.options[ 0 ]?.requiredFlags ?? [];
+}
+
+/**
+ * Returns the disallowed flags from the rule options.
+ *
+ * @param {Object} context The ESLint rule context.
+ * @returns {Array.<String>}
+ */
+function getDisallowedFlagsConfig( context ) {
+	return context.options[ 0 ]?.disallowedFlags ?? [];
+}
+
+/**
+ * Analyzes the plugin class declaration and performs all necessary checks and reports errors if needed.
+ * What it does:
+ *
+ * 	* It checks if there are no disallowed flags.
+ * 	* It checks if all required flags are defined in the class declaration.
+ * 	* It checks if all required flags are defined after the `pluginName` method.
+ * 	* It checks if all required flags are defined in the proper order (after each other).
+ *
+ * While checking the order might be not super important, it's a good practice to keep the flags in the same order
+ * to avoid situations where the flags are scattered across the class. It unifies alignment of the methods with
+ * auto-fixer which enforces defining all flags after the `pluginName` method (mostly because it simplifies the fixer).
+ *
+ * @param {Object} context The ESLint rule context.
+ * @param {Object} classDeclaration The class declaration node to analyze.
+ */
+function analyzePluginClass( context, classDeclaration ) {
+	checkIfThereAreNoDisallowedFlags( context, classDeclaration );
+	checkIfAllFlagsAreProperlyDefined( context, classDeclaration );
+	checkIfFlagsAreDefinedAfterPluginName( context, classDeclaration );
+	checkIfFlagsDefinedInProperOrder( context, classDeclaration );
+}
+
+/**
+ * Checks if there are no disallowed flags defined in the class declaration.
+ *
+ * @param {Object} context The ESLint rule context.
+ * @param {Object} classDeclaration The class declaration node to analyze.
+ * @example
+ *
+ * Let's assume we have the following class declaration:
+ *
+ * ```
+ * class TestPlugin extends Plugin {
+ * 	static get pluginName() { return 'TestPlugin'; }
+ * 	static get isOfficialPlugin() { return true; }
+ * }
+ * ```
+ *
+ * We disallowed the `isOfficialPlugin` method in the rule configuration.
+ *
+ * This check will report an error for the `isOfficialPlugin` method because it's disallowed.
+ * It'll propose removing the method. Keep in mind that it depends on configuration and the disallowed flags might be different,
+ */
+function checkIfThereAreNoDisallowedFlags( context, classDeclaration ) {
+	const staticMembers = getAllStaticMembers( classDeclaration );
+
+	// Check if there is no absent flag defined in the class. If it is, report an error and propose fix.
+	for ( const disallowedFlag of getDisallowedFlagsConfig( context ) ) {
+		const definedNode = staticMembers.find( element => element.key?.name === disallowedFlag );
+
+		// Check if the class has a static getter method with the required name.
+		if ( definedNode ) {
+			context.report( {
+				node: definedNode,
+				fix: createRemoveClassMembersFixer( context, classDeclaration, [ disallowedFlag ] ),
+				messageId: 'disallowedFlag',
+				data: {
+					flag: disallowedFlag
+				}
+			} );
+		}
+	}
+}
+
+/**
+ * Checks if all required flags are properly defined in the class declaration.
+ *
+ * @param {Object} context The ESLint rule context.
+ * @param {ASTNode} classDeclaration The class declaration node to analyze.
+ * @example
+ *
+ * Scenario #1, missing required flag:
+ *
+ * Let's assume we have the following class declaration:
+ *
+ * ```
+ * class TestPlugin extends Plugin {
+ * 	static get pluginName() { return 'TestPlugin'; }
+ * }
+ * ```
+ *
+ * This check will report an error for the `isOfficialPlugin` method because it's missing.
+ * Keep in mind that it depends on configuration and the required flags might be different,
+ * so it's not always `isOfficialPlugin`.
+ *
+ * ---
+ *
+ * Scenario #2, incorrect return value:
+ *
+ * Let's assume we have the following class declaration:
+ *
+ * ```
+ * class TestPlugin extends Plugin {
+ * 	static get pluginName() { return 'TestPlugin'; }
+ * 	static get isOfficialPlugin() { return false; }
+ * }
+ * ```
+ *
+ * This check will report an error for the `isOfficialPlugin` method because
+ * it should return `true` but returns `false` instead.
+ */
+function checkIfAllFlagsAreProperlyDefined( context, classDeclaration ) {
+	const staticClassGetters = getAllStaticGetters( classDeclaration );
+
+	// Check if every required flag is defined in the class and propose fixes if not.
+	for ( const requiredFlag of getRequiredFlagsConfig( context ) ) {
+		const definedMethod = staticClassGetters.find( element => element.key.name === requiredFlag.name );
+
+		// Check if the class has a static getter method with the required name.
+		if ( !definedMethod ) {
+			context.report( {
+				node: classDeclaration,
+				fix: createPluginsFlagsFixer( context, classDeclaration ),
+				messageId: 'missingRequiredFlag',
+				data: {
+					flag: requiredFlag.name,
+					returnValue: requiredFlag.returnValue
+				}
+			} );
+
+			continue;
+		}
+
+		// Check if method is defined as a public getter method
+		// It's not crucial for other eslint rules in this loop, so we can continue loop.
+		if ( !definedMethod.accessibility || definedMethod.accessibility !== 'public' ) {
+			context.report( {
+				node: definedMethod,
+				fix: createPluginsFlagsFixer( context, classDeclaration ),
+				messageId: 'notPublicGetter',
+				data: {
+					flag: requiredFlag.name
+				}
+			} );
+		}
+
+		// Check if the method has a proper return type defined. In our scenario it should be equal to
+		// `requiredFlag.returnValue` which is a boolean. Keep convention from the `ContextPlugin#isContextPlugin` method.
+		if ( definedMethod.value?.returnType?.typeAnnotation?.literal?.value !== requiredFlag.returnValue ) {
+			context.report( {
+				node: definedMethod,
+				fix: createPluginsFlagsFixer( context, classDeclaration ),
+				messageId: 'incorrectReturnValue',
+				data: {
+					flag: requiredFlag.name,
+					returnValue: requiredFlag.returnValue,
+					actualValue: definedMethod.value?.returnType?.typeAnnotation?.literal?.value
+				}
+			} );
+		}
+
+		// Prevent adding advanced logic to the flag method. It should be a simple getter with single return statement.
+		const { body: methodBody } = definedMethod.value.body;
+
+		if ( methodBody.length !== 1 || methodBody[ 0 ].type !== 'ReturnStatement' ) {
+			context.report( {
+				node: definedMethod,
+				fix: createPluginsFlagsFixer( context, classDeclaration ),
+				messageId: 'singleReturnStatement',
+				data: {
+					flag: requiredFlag.name
+				}
+			} );
+
+			continue;
+		}
+
+		// Check if the method returns the required value and that the value is a literal.
+		const { argument } = methodBody[ 0 ];
+
+		if ( argument.type !== 'Literal' || argument.value !== requiredFlag.returnValue ) {
+			context.report( {
+				node: argument,
+				fix: createPluginsFlagsFixer( context, classDeclaration ),
+				messageId: 'incorrectReturnLiteral',
+				data: {
+					flag: requiredFlag.name,
+					returnValue: requiredFlag.returnValue
+				}
+			} );
+		}
+	}
+}
+
+/**
+ * Checks if all required flags are defined **after** the `pluginName` method.
+ *
+ * @param {Object} context The ESLint rule context.
+ * @param {Object} classDeclaration The class declaration node to analyze.
+ * @example
+ *
+ * Let's assume we have the following class declaration:
+ *
+ * ```
+ * class TestPlugin extends Plugin {
+ * 	static get isPremiumPlugin() { return true; }
+ * 	static get pluginName() { return 'TestPlugin'; }
+ * }
+ * ```
+ *
+ * This check will report an error for the `isPremiumPlugin` method because
+ * it should be defined after the `pluginName` method.
+ */
+function checkIfFlagsAreDefinedAfterPluginName( context, classDeclaration ) {
+	const staticClassGetters = getAllStaticGetters( classDeclaration );
+	const methodsAfterPluginName = staticClassGetters.slice(
+		staticClassGetters.indexOf( getPluginNameMethod( classDeclaration ) ) + 1
+	);
+
+	// Check if every required flag is defined in the proper order.
+	for ( const requiredFlag of getRequiredFlagsConfig( context ) ) {
+		// Check if method is defined somewhere in the class.
+		const flagDefinedSomewhereInClass = staticClassGetters.find(
+			element => element.key.name === requiredFlag.name
+		);
+
+		if ( flagDefinedSomewhereInClass && !methodsAfterPluginName.includes( flagDefinedSomewhereInClass ) ) {
+			context.report( {
+				node: flagDefinedSomewhereInClass,
+				fix: createPluginsFlagsFixer( context, classDeclaration ),
+				messageId: 'definedBeforePluginName',
+				data: {
+					flag: requiredFlag.name
+				}
+			} );
+		}
+	}
+}
+
+/**
+ * Checks if all required flags are defined in the proper order.
+ *
+ * @param {Object} context The ESLint rule context.
+ * @param {Object} classDeclaration The class declaration node to analyze.
+ * @example
+ *
+ * Let's assume we have the following class declaration:
+ *
+ * ```
+ * class TestPlugin extends Plugin {
+ * 	static get pluginName() { return 'TestPlugin'; }
+ * 	static get isOfficialPlugin() { return true; }
+ * 	constructor() { super(); }
+ * 	static get isPremiumPlugin() { return false; }
+ * }
+ * ```
+ *
+ * This check will report an error for the `isPremiumPlugin` method because it
+ * should be defined directly after the `isOfficialPlugin` method.
+ */
+function checkIfFlagsDefinedInProperOrder( context, classDeclaration ) {
+	const orderedMethodsLinkedList = getRequiredFlagsConfig( context ).map( ( flag, index, array ) => ( {
+		name: flag.name,
+		before: {
+			name: array[ index - 1 ]?.name || PLUGIN_NAME_METHOD_NAME
+		}
+	} ) );
+
+	let lastGetterMethod = null;
+
+	for ( const classNode of getAllClassMembers( classDeclaration ) ) {
+		// Ignore if method signature is not a getter or it's not a static method.
+		if ( !isStaticGetterMethod( classNode ) ) {
+			lastGetterMethod = null;
+			continue;
+		}
+
+		// Ignore if method is not a flag method.
+		const flagMethod = orderedMethodsLinkedList.find( element => element.name === classNode.key.name );
+
+		if ( flagMethod ) {
+			if ( !lastGetterMethod ) {
+				// If there is no last method, it means that the current method is the first flag method after
+				// constructor or any other non-flag method. It's bad.
+				context.report( {
+					node: classNode,
+					fix: createPluginsFlagsFixer( context, classDeclaration ),
+					messageId: 'definedInProperOrder',
+					data: {
+						flag: classNode.key.name
+					}
+				} );
+			} else if ( lastGetterMethod && lastGetterMethod.key.name !== flagMethod.before.name ) {
+				// If the last flag method is not the one that should be before the current flag method, report an error.
+				context.report( {
+					node: classNode,
+					fix: createPluginsFlagsFixer( context, classDeclaration ),
+					messageId: 'definedAfterSpecificMethod',
+					data: {
+						flag: classNode.key.name,
+						before: flagMethod.before.name
+					}
+				} );
+			}
+		}
+
+		lastGetterMethod = classNode;
+	}
+}
+
+/**
+ * Creates a fixer for the plugin flags.
+ * It removes all methods that are named as required flags and adds new ones in proper order and place.
+ *
+ * @param {Object} context
+ * @param {Object} classDeclaration
+ * @returns {Function}
+ * @example
+ *
+ * It removes all methods that are named as required flags and adds new ones in proper order and place.
+ * Like in the example below, it will change:
+ *
+ * ```
+ * class TestPlugin extends Plugin {
+ * 	static get pluginName() { return 'TestPlugin'; }
+ * }
+ * ```
+ *
+ * to:
+ *
+ * ```
+ * class TestPlugin extends Plugin {
+ * 	static get pluginName() { return 'TestPlugin'; }
+ *
+ * 	public static get isOfficialPlugin(): true {
+ * 		return true;
+ * 	}
+ * }
+ * ```
+ */
+function createPluginsFlagsFixer( context, classDeclaration ) {
+	const requiredFlags = getRequiredFlagsConfig( context );
+	const removeMethodFixer = createRemoveClassMembersFixer(
+		context,
+		classDeclaration,
+		requiredFlags.map( flag => flag.name )
+	);
+
+	return fixer => {
+		// Remove all methods that are named as required flags.
+		const removedMethodsFixes = removeMethodFixer( fixer );
+
+		// Inject new required flags getters at the top of the class declaration.
+		const pluginNameMethod = getPluginNameMethod( classDeclaration );
+		const indent = '\t'.repeat( pluginNameMethod.loc.start.column );
+
+		const injectedMethodsFixes = requiredFlags.map( ( requiredFlag, index ) => {
+			const isLastIndex = index === requiredFlags.length - 1;
+
+			// Eslint indent handling is a bit tricky. Only the first inserted method line is indented properly.
+			// The next ones need to be indented manually. The last one have have to be indented in both directions
+			// because eslint seems to be removing indention of the `pluginNameMethod` line.
+			const method =
+				`${ index ? '' : '\n\n' }${ indent }/**\n` +
+				`${ indent } * @inheritDoc\n` +
+				`${ indent } */\n` +
+				`${ indent }public static get ${ requiredFlag.name }(): ${ requiredFlag.returnValue } {\n` +
+				`${ indent }\treturn ${ requiredFlag.returnValue };\n` +
+				`${ indent }}${ isLastIndex ? '' : '\n\n' }`;
+
+			return fixer.insertTextAfter( pluginNameMethod, method );
+		} );
+
+		return [
+			...removedMethodsFixes,
+			...injectedMethodsFixes
+		];
+	};
+}
+
+/**
+ * Creates fixer for removing class methods by their names.
+ *
+ * @param {Object} context
+ * @param {Object} classDeclaration
+ * @param {Array.<String>} names
+ * @returns {Function}
+ */
+function createRemoveClassMembersFixer( context, classDeclaration, names ) {
+	// Cache last removed new line to avoid overlapping ranges during removal of multiple methods
+	let lastRemovedNewLine = 0;
+
+	// Remove all methods that are named like the flags.
+	return fixer => {
+		const ranges = getAllClassMembers( classDeclaration )
+			.filter( element => names.includes( element.key?.name ) )
+			.map( method => {
+				const sourceCode = context.getSourceCode();
+				const commentsBeforeMethod = sourceCode.getCommentsBefore( method );
+
+				const endRange = sourceCode.text.indexOf( '\n', method.range[ 1 ] ) + 1;
+				let startRange = sourceCode.text.lastIndexOf( '\n', commentsBeforeMethod[ 0 ]?.range[ 0 ] || method.range[ 0 ] );
+
+				// Prevent incorrect formatting of the methods that have no space between them.
+				// It prevents eating new line from the previous method.
+				if ( sourceCode.text[ startRange - 1 ].trim() === '}' ) {
+					startRange++;
+				}
+
+				// It prevents overlapping ranges when removing multiple methods.
+				// From time to time endline from previous and current method are the same which causes eslint to throw an error.
+				if ( startRange < lastRemovedNewLine ) {
+					startRange = lastRemovedNewLine + 1;
+				}
+
+				lastRemovedNewLine = endRange;
+
+				return [ startRange, endRange ];
+			} );
+
+		// Detect overlapping ranges before creating fixes. It's better to report a warning
+		// than crashing whole eslint process. This usually happens when the parser struggles with
+		// removing multiple methods at once that share the same endline. It should be handled in the code above
+		// but it's better to have a safety net here.
+		for ( let i = 0; i < ranges.length - 1; i++ ) {
+			// It looks like ranges overlap lets abort the fixer.
+			if ( ranges[ i ][ 1 ] > ranges[ i + 1 ][ 0 ] ) {
+				return [];
+			}
+		}
+
+		return ranges.map( range => fixer.removeRange( range ) );
+	};
+}
+
+/**
+ * Returns true if the class declaration extends the Plugin or ContextPlugin class.
+ *
+ * @param {Object} classDeclaration
+ * @returns {Boolean}
+ * @example
+ *
+ * Let's assume we have the following class declaration:
+ *
+ * ```
+ * class TestPlugin extends Plugin {
+ * 	static get pluginName() { return 'TestPlugin'; }
+ * }
+ * ```
+ *
+ * isPluginClassDeclaration( node ); // true
+ */
+function isPluginClassDeclaration( classDeclaration ) {
+	// Check if the class extends the Plugin or ContextPlugin class.
+	if ( ![ 'Plugin', 'ContextPlugin' ].includes( classDeclaration.superClass?.name ) ) {
+		return false;
+	}
+
+	// Check if the class has a static getter method that returns the plugin name.
+	return !!getPluginNameMethod( classDeclaration );
+}
+
+/**
+ * Retrieves the method that gets the plugin name from a class declaration.
+ *
+ * @param {Object} classDeclaration - The class declaration node to search for the plugin name method.
+ * @returns {Object|undefined} The method node if found, otherwise undefined.
+ */
+function getPluginNameMethod( classDeclaration ) {
+	return getAllStaticGetters( classDeclaration ).find( element => element.key.name === PLUGIN_NAME_METHOD_NAME );
+}
+
+/**
+ * Returns all static getters from the class declaration
+ *
+ * @param {Object} classDeclaration
+ * @returns {Array.<Object>}
+ * @example
+ * ```
+ * getAllClassDeclarationMethods( node ); // [ { type: 'MethodDefinition', key: { name: 'pluginName' }, static: true }, ... ]
+ * ```
+ */
+function getAllStaticGetters( classDeclaration ) {
+	return getAllClassMembers( classDeclaration ).filter( isStaticGetterMethod );
+}
+
+/**
+ * Returns all static members from the class declaration
+ *
+ * @param {Object} classDeclaration
+ * @returns {Array.<Object>}
+ */
+function getAllStaticMembers( classDeclaration ) {
+	return getAllClassMembers( classDeclaration ).filter( node => node.static );
+}
+
+/**
+ * Returns all class body nodes.
+ *
+ * @param {Object} classDeclaration
+ * @returns {Array.<Object>} The class body nodes.
+ */
+function getAllClassMembers( classDeclaration ) {
+	return classDeclaration.body.body;
+}
+
+/**
+ * Returns true if the method is a static getter method.
+ *
+ * @param {Object} method
+ * @returns {Boolean} True if the method is a static getter method.
+ */
+function isStaticGetterMethod( method ) {
+	return method.static && method.type === 'MethodDefinition' && method.kind === 'get';
+}

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/ckeditor-plugin-flags.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/ckeditor-plugin-flags.js
@@ -10,7 +10,6 @@ const PLUGIN_NAME_METHOD_NAME = 'pluginName';
 module.exports = {
 	meta: {
 		type: 'problem',
-		fixable: 'code',
 		docs: {
 			description: 'Enforce the presence of the plugin flags.',
 			category: 'CKEditor5'

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/ckeditor-plugin-flags.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/ckeditor-plugin-flags.js
@@ -57,7 +57,8 @@ module.exports = {
 		return {
 			'ClassDeclaration:exit'( classDeclaration ) {
 				if ( isPluginClassDeclaration( classDeclaration ) ) {
-					analyzePluginClass( context, classDeclaration );
+					checkIfThereAreNoDisallowedFlags( context, classDeclaration );
+					checkIfAllFlagsAreProperlyDefined( context, classDeclaration );
 				}
 			}
 		};
@@ -82,27 +83,6 @@ function getRequiredFlagsConfig( context ) {
  */
 function getDisallowedFlagsConfig( context ) {
 	return context.options[ 0 ]?.disallowedFlags ?? [];
-}
-
-/**
- * Analyzes the plugin class declaration and performs all necessary checks and reports errors if needed.
- * What it does:
- *
- * 	* It checks if there are no disallowed flags.
- * 	* It checks if all required flags are defined in the class declaration.
- * 	* It checks if all required flags are defined after the `pluginName` method.
- * 	* It checks if all required flags are defined in the proper order (after each other).
- *
- * While checking the order might be not super important, it's a good practice to keep the flags in the same order
- * to avoid situations where the flags are scattered across the class. It unifies alignment of the methods with
- * auto-fixer which enforces defining all flags after the `pluginName` method (mostly because it simplifies the fixer).
- *
- * @param {Object} context The ESLint rule context.
- * @param {Object} classDeclaration The class declaration node to analyze.
- */
-function analyzePluginClass( context, classDeclaration ) {
-	checkIfThereAreNoDisallowedFlags( context, classDeclaration );
-	checkIfAllFlagsAreProperlyDefined( context, classDeclaration );
 }
 
 /**

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/ckeditor-plugin-flags.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/ckeditor-plugin-flags.js
@@ -46,12 +46,7 @@ module.exports = {
 			disallowedFlag: 'The class member \'{{flag}}\' is disallowed here and should be removed.',
 			missingRequiredFlag: 'The class should have a static getter method \'{{flag}}\' that returns {{returnValue}}.',
 			incorrectReturnValue: 'The method \'{{flag}}\' should return {{returnValue}} but returns {{actualValue}} instead.',
-			incorrectReturnLiteral: 'The method \'{{flag}}\' should return a literal value with the {{returnValue}} value.',
-			notPublicGetter: 'The method \'{{flag}}\' should be defined as a public getter method.',
-			singleReturnStatement: 'The method \'{{flag}}\' should have a single return statement.',
-			definedBeforePluginName: 'The method \'{{flag}}\' should be defined after the \'pluginName\' method.',
-			definedInProperOrder: 'The method \'{{flag}}\' should be defined directly after other flag method.',
-			definedAfterSpecificMethod: 'The method \'{{flag}}\' should be defined after the \'{{before}}\' method.'
+			notPublicGetter: 'The method \'{{flag}}\' should be defined as a public getter method.'
 		}
 	},
 
@@ -109,10 +104,6 @@ function getDisallowedFlagsConfig( context ) {
 function analyzePluginClass( context, classDeclaration ) {
 	checkIfThereAreNoDisallowedFlags( context, classDeclaration );
 	checkIfAllFlagsAreProperlyDefined( context, classDeclaration );
-
-	const misalignedMethods = checkIfFlagsAreDefinedAfterPluginName( context, classDeclaration );
-
-	checkIfFlagsDefinedInProperOrder( context, classDeclaration, misalignedMethods );
 }
 
 /**
@@ -147,7 +138,6 @@ function checkIfThereAreNoDisallowedFlags( context, classDeclaration ) {
 		if ( definedNode ) {
 			context.report( {
 				node: definedNode,
-				fix: createRemoveClassMembersFixer( context, classDeclaration, [ disallowedFlag ] ),
 				messageId: 'disallowedFlag',
 				data: {
 					flag: disallowedFlag
@@ -205,7 +195,6 @@ function checkIfAllFlagsAreProperlyDefined( context, classDeclaration ) {
 		if ( !definedMethod ) {
 			context.report( {
 				node: classDeclaration,
-				fix: createPluginsFlagsFixer( context, classDeclaration ),
 				messageId: 'missingRequiredFlag',
 				data: {
 					flag: requiredFlag.name,
@@ -221,7 +210,6 @@ function checkIfAllFlagsAreProperlyDefined( context, classDeclaration ) {
 		if ( !definedMethod.accessibility || definedMethod.accessibility !== 'public' ) {
 			context.report( {
 				node: definedMethod,
-				fix: createPluginsFlagsFixer( context, classDeclaration ),
 				messageId: 'notPublicGetter',
 				data: {
 					flag: requiredFlag.name
@@ -234,7 +222,6 @@ function checkIfAllFlagsAreProperlyDefined( context, classDeclaration ) {
 		if ( definedMethod.value?.returnType?.typeAnnotation?.literal?.value !== requiredFlag.returnValue ) {
 			context.report( {
 				node: definedMethod,
-				fix: createPluginsFlagsFixer( context, classDeclaration ),
 				messageId: 'incorrectReturnValue',
 				data: {
 					flag: requiredFlag.name,
@@ -243,301 +230,7 @@ function checkIfAllFlagsAreProperlyDefined( context, classDeclaration ) {
 				}
 			} );
 		}
-
-		// Prevent adding advanced logic to the flag method. It should be a simple getter with single return statement.
-		const { body: methodBody } = definedMethod.value.body;
-
-		if ( methodBody.length !== 1 || methodBody[ 0 ].type !== 'ReturnStatement' ) {
-			context.report( {
-				node: definedMethod,
-				fix: createPluginsFlagsFixer( context, classDeclaration ),
-				messageId: 'singleReturnStatement',
-				data: {
-					flag: requiredFlag.name
-				}
-			} );
-
-			continue;
-		}
-
-		// Check if the method returns the required value and that the value is a literal.
-		const { argument } = methodBody[ 0 ];
-
-		if ( argument.type !== 'Literal' || argument.value !== requiredFlag.returnValue ) {
-			context.report( {
-				node: argument,
-				fix: createPluginsFlagsFixer( context, classDeclaration ),
-				messageId: 'incorrectReturnLiteral',
-				data: {
-					flag: requiredFlag.name,
-					returnValue: requiredFlag.returnValue
-				}
-			} );
-		}
 	}
-}
-
-/**
- * Checks if all required flags are defined **after** the `pluginName` method.
- *
- * @param {Object} context The ESLint rule context.
- * @param {Object} classDeclaration The class declaration node to analyze.
- * @returns {Array.<Object>} A list of methods that should be ignored in the next check.
- * @example
- *
- * Let's assume we have the following class declaration:
- *
- * ```
- * class TestPlugin extends Plugin {
- * 	static get isPremiumPlugin() { return true; }
- * 	static get pluginName() { return 'TestPlugin'; }
- * }
- * ```
- *
- * This check will report an error for the `isPremiumPlugin` method because
- * it should be defined after the `pluginName` method.
- */
-function checkIfFlagsAreDefinedAfterPluginName( context, classDeclaration ) {
-	const staticClassGetters = getAllStaticGetters( classDeclaration );
-	const methodsAfterPluginName = staticClassGetters.slice(
-		staticClassGetters.indexOf( getPluginNameMethod( classDeclaration ) ) + 1
-	);
-
-	// Check if every required flag is defined in the proper order
-	// If not then collect all methods that are in the wrong order to ignore them in the next check.
-	const flagsDefinedBeforePluginName = getRequiredFlagsConfig( context ).flatMap( requiredFlag => {
-		const matchedGettersBeforeRequiredFlag = staticClassGetters.filter(
-			staticGetter =>
-				staticGetter.key.name === requiredFlag.name &&
-				!methodsAfterPluginName.includes( staticGetter )
-		);
-
-		if ( matchedGettersBeforeRequiredFlag.length ) {
-			return [ [ requiredFlag, matchedGettersBeforeRequiredFlag ] ];
-		}
-
-		return [];
-	} );
-
-	// Report an error for every flag that is defined before the `pluginName` method.
-	for ( const [ requiredFlag, methodsSomewhereInClass ] of flagsDefinedBeforePluginName ) {
-		// There is edge case scenario where the flag is defined multiple times in the class so handle it as well.
-		for ( const affectedMethod of methodsSomewhereInClass ) {
-			context.report( {
-				node: affectedMethod,
-				fix: createPluginsFlagsFixer( context, classDeclaration ),
-				messageId: 'definedBeforePluginName',
-				data: {
-					flag: requiredFlag.name
-				}
-			} );
-		}
-	}
-
-	// Return plain list of methods that are in the wrong order to ignore them in the next check.
-	return flagsDefinedBeforePluginName.flatMap( ( [ , methodsSomewhereInClass ] ) => methodsSomewhereInClass );
-}
-
-/**
- * Checks if all required flags are defined in the proper order.
- *
- * @param {Object} context The ESLint rule context.
- * @param {Object} classDeclaration The class declaration node to analyze.
- * @param {Array.<Object>} ignoredMethods A list of methods that should be ignored during the check.
- * @example
- *
- * Let's assume we have the following class declaration:
- *
- * ```
- * class TestPlugin extends Plugin {
- * 	static get pluginName() { return 'TestPlugin'; }
- * 	static get isOfficialPlugin() { return true; }
- * 	constructor() { super(); }
- * 	static get isPremiumPlugin() { return false; }
- * }
- * ```
- *
- * This check will report an error for the `isPremiumPlugin` method because it
- * should be defined directly after the `isOfficialPlugin` method.
- */
-function checkIfFlagsDefinedInProperOrder( context, classDeclaration, ignoredMethods = [] ) {
-	const orderedMethodsLinkedList = getRequiredFlagsConfig( context ).map( ( flag, index, array ) => ( {
-		name: flag.name,
-		before: {
-			name: array[ index - 1 ]?.name || PLUGIN_NAME_METHOD_NAME
-		}
-	} ) );
-
-	let lastGetterMethod = null;
-
-	for ( const classNode of getAllClassMembers( classDeclaration ) ) {
-		// Ignore if method signature is not a getter or it's not a static method.
-		if ( !isStaticGetterMethod( classNode ) ) {
-			lastGetterMethod = null;
-			continue;
-		}
-
-		// Check if method was reported by one of previous analyzers. If so, ignore it, do not report similar error twice.
-		if ( ignoredMethods.includes( classNode ) ) {
-			continue;
-		}
-
-		// Ignore if method is not a flag method.
-		const flagMethod = orderedMethodsLinkedList.find( element => element.name === classNode.key.name );
-
-		if ( flagMethod ) {
-			if ( !lastGetterMethod ) {
-				// If there is no last method, it means that the current method is the first flag method after
-				// constructor or any other non-flag method. It's bad.
-				context.report( {
-					node: classNode,
-					fix: createPluginsFlagsFixer( context, classDeclaration ),
-					messageId: 'definedInProperOrder',
-					data: {
-						flag: classNode.key.name
-					}
-				} );
-			} else if ( lastGetterMethod && lastGetterMethod.key.name !== flagMethod.before.name ) {
-				// If the last flag method is not the one that should be before the current flag method, report an error.
-				context.report( {
-					node: classNode,
-					fix: createPluginsFlagsFixer( context, classDeclaration ),
-					messageId: 'definedAfterSpecificMethod',
-					data: {
-						flag: classNode.key.name,
-						before: flagMethod.before.name
-					}
-				} );
-			}
-		}
-
-		lastGetterMethod = classNode;
-	}
-}
-
-/**
- * Creates a fixer for the plugin flags.
- * It removes all methods that are named as required flags and adds new ones in proper order and place.
- *
- * @param {Object} context
- * @param {Object} classDeclaration
- * @returns {Function}
- * @example
- *
- * It removes all methods that are named as required flags and adds new ones in proper order and place.
- * Like in the example below, it will change:
- *
- * ```
- * class TestPlugin extends Plugin {
- * 	static get pluginName() { return 'TestPlugin'; }
- * }
- * ```
- *
- * to:
- *
- * ```
- * class TestPlugin extends Plugin {
- * 	static get pluginName() { return 'TestPlugin'; }
- *
- * 	public static get isOfficialPlugin(): true {
- * 		return true;
- * 	}
- * }
- * ```
- */
-function createPluginsFlagsFixer( context, classDeclaration ) {
-	const requiredFlags = getRequiredFlagsConfig( context );
-	const removeMethodFixer = createRemoveClassMembersFixer(
-		context,
-		classDeclaration,
-		requiredFlags.map( flag => flag.name )
-	);
-
-	return fixer => {
-		// Remove all methods that are named as required flags.
-		const removedMethodsFixes = removeMethodFixer( fixer );
-
-		// Inject new required flags getters at the top of the class declaration.
-		const pluginNameMethod = getPluginNameMethod( classDeclaration );
-		const indent = '\t'.repeat( pluginNameMethod.loc.start.column );
-
-		const injectedMethodsFixes = requiredFlags.map( ( requiredFlag, index ) => {
-			const isLastIndex = index === requiredFlags.length - 1;
-
-			// Eslint indent handling is a bit tricky. Only the first inserted method line is indented properly.
-			// The next ones need to be indented manually. The last one have have to be indented in both directions
-			// because eslint seems to be removing indention of the `pluginNameMethod` line.
-			const method =
-				`${ index ? '' : '\n\n' }${ indent }/**\n` +
-				`${ indent } * @inheritDoc\n` +
-				`${ indent } */\n` +
-				`${ indent }public static override get ${ requiredFlag.name }(): ${ requiredFlag.returnValue } {\n` +
-				`${ indent }\treturn ${ requiredFlag.returnValue };\n` +
-				`${ indent }}${ isLastIndex ? '' : '\n\n' }`;
-
-			return fixer.insertTextAfter( pluginNameMethod, method );
-		} );
-
-		return [
-			...removedMethodsFixes,
-			...injectedMethodsFixes
-		];
-	};
-}
-
-/**
- * Creates fixer for removing class methods by their names.
- *
- * @param {Object} context
- * @param {Object} classDeclaration
- * @param {Array.<String>} names
- * @returns {Function}
- */
-function createRemoveClassMembersFixer( context, classDeclaration, names ) {
-	// Cache last removed new line to avoid overlapping ranges during removal of multiple methods
-	let lastRemovedNewLine = 0;
-
-	// Remove all methods that are named like the flags.
-	return fixer => {
-		const ranges = getAllClassMembers( classDeclaration )
-			.filter( element => names.includes( element.key?.name ) )
-			.map( method => {
-				const sourceCode = context.getSourceCode();
-				const commentsBeforeMethod = sourceCode.getCommentsBefore( method );
-
-				const endRange = sourceCode.text.indexOf( '\n', method.range[ 1 ] ) + 1;
-				let startRange = sourceCode.text.lastIndexOf( '\n', commentsBeforeMethod[ 0 ]?.range[ 0 ] || method.range[ 0 ] );
-
-				// Prevent incorrect formatting of the methods that have no space between them.
-				// It prevents eating new line from the previous method.
-				if ( sourceCode.text[ startRange - 1 ].trim() === '}' ) {
-					startRange++;
-				}
-
-				// It prevents overlapping ranges when removing multiple methods.
-				// From time to time endline from previous and current method are the same which causes eslint to throw an error.
-				if ( startRange < lastRemovedNewLine ) {
-					startRange = lastRemovedNewLine + 1;
-				}
-
-				lastRemovedNewLine = endRange;
-
-				return [ startRange, endRange ];
-			} );
-
-		// Detect overlapping ranges before creating fixes. It's better to report a warning
-		// than crashing whole eslint process. This usually happens when the parser struggles with
-		// removing multiple methods at once that share the same endline. It should be handled in the code above
-		// but it's better to have a safety net here.
-		for ( let i = 0; i < ranges.length - 1; i++ ) {
-			// It looks like ranges overlap lets abort the fixer.
-			if ( ranges[ i ][ 1 ] > ranges[ i + 1 ][ 0 ] ) {
-				return [];
-			}
-		}
-
-		return ranges.map( range => fixer.removeRange( range ) );
-	};
 }
 
 /**

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/ckeditor-plugin-flags.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/ckeditor-plugin-flags.js
@@ -1,0 +1,542 @@
+/**
+ * @license Copyright (c) 2003-2024, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const RuleTester = require( 'eslint' ).RuleTester;
+
+const ruleTester = new RuleTester( {
+	parser: require.resolve( '@typescript-eslint/parser' )
+} );
+
+ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plugin-flags' ), {
+	valid: [
+		// Should not raise any error when empty non-plugin class is checked.
+		{
+			code: 'class Abc {}',
+			options: [
+				{
+					requiredFlags: [
+						{
+							name: 'isOfficialPlugin',
+							returnValue: true
+						}
+					]
+				}
+			]
+		},
+
+		// Check if class that does not extend Plugin is not checked.
+		{
+			code: 'class TestNonPlugin { static get pluginName() { return \'TestNonPlugin\'; } }',
+			options: [
+				{
+					requiredFlags: [
+						{
+							name: 'isOfficialPlugin',
+							returnValue: true
+						}
+					]
+				}
+			]
+		},
+
+		// Check if class that extends Plugin but do not define pluginName is not checked.
+		{
+			code: 'class TestPlugin extends Plugin {}',
+			options: [
+				{
+					requiredFlags: [
+						{
+							name: 'isOfficialPlugin',
+							returnValue: true
+						}
+					]
+				}
+			]
+		},
+
+		// Check if class containing specified methods is checked.
+		{
+			code: `
+				class TestPlugin extends Plugin {
+					static get pluginName() { return 'TestPlugin'; }
+					public static get isOfficialPlugin(): true { return true; }
+					public static get isPremiumPlugin(): false { return false; }
+				}
+			`,
+			options: [
+				{
+					requiredFlags: [
+						{
+							name: 'isOfficialPlugin',
+							returnValue: true
+						},
+						{
+							name: 'isPremiumPlugin',
+							returnValue: false
+						}
+					]
+				}
+			]
+		}
+	],
+	invalid: [
+		// Should properly fix non-spaced method definition when there are multiple disallowed flags.
+		{
+			code: `
+				class TestPlugin extends Plugin {
+					static get pluginName() { return 'TestPlugin'; }
+					public static get isOfficialPlugin(): true { return true; }
+					public static get isPremiumPlugin(): false { return false; }
+					public static get isNotOfficialPlugin(): false { return false; }
+				}
+			`,
+			output: `
+				class TestPlugin extends Plugin {
+					static get pluginName() { return 'TestPlugin'; }
+					public static get isPremiumPlugin(): false { return false; }
+				}
+			`,
+			options: [
+				{
+					disallowedFlags: [ 'isOfficialPlugin', 'isNotOfficialPlugin' ]
+				}
+			],
+			errors: [
+				{ messageId: 'disallowedFlag' },
+				{ messageId: 'disallowedFlag' }
+			]
+		},
+
+		// Should raise error if there is disallowed properties in the class.
+		{
+			code: `
+				class TestPlugin extends Plugin {
+					static get pluginName() { return 'TestPlugin'; }
+
+					public static get isOfficialPlugin(): true { return true; }
+
+					public static get isPremiumPlugin(): false { return false; }
+
+					public static get isNotOfficialPlugin(): false { return false; }
+				}
+			`,
+			output: `
+				class TestPlugin extends Plugin {
+					static get pluginName() { return 'TestPlugin'; }
+
+					public static get isPremiumPlugin(): false { return false; }
+				}
+			`,
+			options: [
+				{
+					disallowedFlags: [ 'isOfficialPlugin', 'isNotOfficialPlugin' ]
+				}
+			],
+			errors: [
+				{ messageId: 'disallowedFlag' },
+				{ messageId: 'disallowedFlag' }
+			]
+		},
+
+		// Should raise error when plugin class does not have required flags.
+		{
+			code: `
+				class TestNonPlugin extends Plugin {
+					static get pluginName() { return 'TestNonPlugin'; }
+				}
+			`,
+			output: `
+				class TestNonPlugin extends Plugin {
+					static get pluginName() { return 'TestNonPlugin'; }
+
+					/**
+					 * @inheritDoc
+					 */
+					public static get isOfficialPlugin(): true {
+						return true;
+					}
+
+					/**
+					 * @inheritDoc
+					 */
+					public static get isPremiumPlugin(): true {
+						return true;
+					}
+				}
+			`,
+			options: [
+				{
+					requiredFlags: [
+						{
+							name: 'isOfficialPlugin',
+							returnValue: true
+						},
+						{
+							name: 'isPremiumPlugin',
+							returnValue: true
+						}
+					]
+				}
+			],
+			errors: [
+				{ messageId: 'missingRequiredFlag' },
+				{ messageId: 'missingRequiredFlag' }
+			]
+		},
+
+		// Should properly fix non spaced method definition when there are multiple required flags.
+		{
+			code: `
+				class TestPlugin extends Plugin {
+					static get pluginName() { return 'TestPlugin'; }
+					public static get isOfficialPlugin(): false { return false; }
+					public static get isPremiumPlugin(): true { return true; }
+					public foo() {}
+				}
+			`,
+			output: `
+				class TestPlugin extends Plugin {
+					static get pluginName() { return 'TestPlugin'; }
+
+					/**
+					 * @inheritDoc
+					 */
+					public static get isOfficialPlugin(): true {
+						return true;
+					}
+
+					/**
+					 * @inheritDoc
+					 */
+					public static get isPremiumPlugin(): false {
+						return false;
+					}
+					public foo() {}
+				}
+			`,
+			options: [
+				{
+					requiredFlags: [
+						{
+							name: 'isOfficialPlugin',
+							returnValue: true
+						},
+						{
+							name: 'isPremiumPlugin',
+							returnValue: false
+						}
+					]
+				}
+			],
+			errors: [
+				{ messageId: 'incorrectReturnValue' },
+				{ messageId: 'incorrectReturnLiteral' },
+				{ messageId: 'incorrectReturnValue' },
+				{ messageId: 'incorrectReturnLiteral' }
+			]
+		},
+
+		// Should raise error when plugin class has required flags with wrong return value.
+		{
+			code: `
+				class TestPlugin extends Plugin {
+					static get pluginName() { return 'TestPlugin'; }
+
+					public static get isOfficialPlugin(): false { return false; }
+
+					public static get isPremiumPlugin(): true { return true; }
+				}
+			`,
+			output: `
+				class TestPlugin extends Plugin {
+					static get pluginName() { return 'TestPlugin'; }
+
+					/**
+					 * @inheritDoc
+					 */
+					public static get isOfficialPlugin(): true {
+						return true;
+					}
+
+					/**
+					 * @inheritDoc
+					 */
+					public static get isPremiumPlugin(): false {
+						return false;
+					}
+				}
+			`,
+			options: [
+				{
+					requiredFlags: [
+						{
+							name: 'isOfficialPlugin',
+							returnValue: true
+						},
+						{
+							name: 'isPremiumPlugin',
+							returnValue: false
+						}
+					]
+				}
+			],
+			errors: [
+				{ messageId: 'incorrectReturnValue' },
+				{ messageId: 'incorrectReturnLiteral' },
+				{ messageId: 'incorrectReturnValue' },
+				{ messageId: 'incorrectReturnLiteral' }
+			]
+		},
+
+		// Should raise error if return value is not a single return statement.
+		{
+			code: `
+				class TestPlugin extends Plugin {
+					static get pluginName() { return 'TestPlugin'; }
+
+					public static get isOfficialPlugin(): true {
+						if ( true ) {
+							return true;
+						}
+
+						return false;
+					}
+				}
+			`,
+			output: `
+				class TestPlugin extends Plugin {
+					static get pluginName() { return 'TestPlugin'; }
+
+					/**
+					 * @inheritDoc
+					 */
+					public static get isOfficialPlugin(): true {
+						return true;
+					}
+				}
+			`,
+			options: [
+				{
+					requiredFlags: [
+						{
+							name: 'isOfficialPlugin',
+							returnValue: true
+						}
+					]
+				}
+			],
+			errors: [
+				{ messageId: 'singleReturnStatement' }
+			]
+		},
+
+		// Should raise error if method has no public modifier.
+		{
+			code: `
+				class TestPlugin extends Plugin {
+					static get pluginName() { return 'TestPlugin'; }
+
+					private static get isOfficialPlugin(): true { return true; }
+				}
+			`,
+			output: `
+				class TestPlugin extends Plugin {
+					static get pluginName() { return 'TestPlugin'; }
+
+					/**
+					 * @inheritDoc
+					 */
+					public static get isOfficialPlugin(): true {
+						return true;
+					}
+				}
+			`,
+			options: [
+				{
+					requiredFlags: [
+						{
+							name: 'isOfficialPlugin',
+							returnValue: true
+						}
+					]
+				}
+			],
+			errors: [
+				{ messageId: 'notPublicGetter' }
+			]
+		},
+
+		// Should raise error if flag is defined before pluginName.
+		{
+			code: `
+				class TestPlugin extends Plugin {
+					/**
+					 * @inheritDoc
+					 */
+					public static get isOfficialPlugin(): true {
+						return true;
+					}
+
+					static get pluginName() { return 'TestPlugin'; }
+				}
+			`,
+			output: `
+				class TestPlugin extends Plugin {
+					static get pluginName() { return 'TestPlugin'; }
+
+					/**
+					 * @inheritDoc
+					 */
+					public static get isOfficialPlugin(): true {
+						return true;
+					}
+				}
+			`,
+			options: [
+				{
+					requiredFlags: [
+						{
+							name: 'isOfficialPlugin',
+							returnValue: true
+						}
+					]
+				}
+			],
+			errors: [
+				{ messageId: 'definedBeforePluginName' },
+				{ messageId: 'definedInProperOrder' }
+			]
+		},
+
+		// Should raise error if flags are not defined in proper order.
+		{
+			code: `
+				class TestPlugin extends Plugin {
+					static get pluginName() { return 'TestPlugin'; }
+
+					/**
+					 * @inheritDoc
+					 */
+					public static get isPremiumPlugin(): false {
+						return false;
+					}
+
+					/**
+					 * @inheritDoc
+					 */
+					public static get isOfficialPlugin(): true {
+						return true;
+					}
+				}
+			`,
+			output: `
+				class TestPlugin extends Plugin {
+					static get pluginName() { return 'TestPlugin'; }
+
+					/**
+					 * @inheritDoc
+					 */
+					public static get isOfficialPlugin(): true {
+						return true;
+					}
+
+					/**
+					 * @inheritDoc
+					 */
+					public static get isPremiumPlugin(): false {
+						return false;
+					}
+				}
+			`,
+			options: [
+				{
+					requiredFlags: [
+						{
+							name: 'isOfficialPlugin',
+							returnValue: true
+						},
+						{
+							name: 'isPremiumPlugin',
+							returnValue: false
+						}
+					]
+				}
+			],
+			errors: [
+				{ messageId: 'definedAfterSpecificMethod' },
+				{ messageId: 'definedAfterSpecificMethod' }
+			]
+		},
+
+		// Should raise error about incorrect flags order if there is constructor between flags.
+		{
+			code: `
+				class TestPlugin extends Plugin {
+					static get pluginName() { return 'TestPlugin'; }
+
+					/**
+					 * @inheritDoc
+					 */
+					public static get isOfficialPlugin(): true {
+						return true;
+					}
+
+					constructor() {
+						super();
+					}
+
+					/**
+					 * @inheritDoc
+					 */
+					public static get isPremiumPlugin(): false {
+						return false;
+					}
+				}
+			`,
+			output: `
+				class TestPlugin extends Plugin {
+					static get pluginName() { return 'TestPlugin'; }
+
+					/**
+					 * @inheritDoc
+					 */
+					public static get isOfficialPlugin(): true {
+						return true;
+					}
+
+					/**
+					 * @inheritDoc
+					 */
+					public static get isPremiumPlugin(): false {
+						return false;
+					}
+
+					constructor() {
+						super();
+					}
+				}
+			`,
+			options: [
+				{
+					requiredFlags: [
+						{
+							name: 'isOfficialPlugin',
+							returnValue: true
+						},
+						{
+							name: 'isPremiumPlugin',
+							returnValue: false
+						}
+					]
+				}
+			],
+			errors: [
+				{ messageId: 'definedInProperOrder' }
+			]
+		}
+	]
+} );

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/ckeditor-plugin-flags.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/ckeditor-plugin-flags.js
@@ -63,8 +63,8 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 			code: `
 				class TestPlugin extends Plugin {
 					static get pluginName() { return 'TestPlugin'; }
-					public static get isOfficialPlugin(): true { return true; }
-					public static get isPremiumPlugin(): false { return false; }
+					public static override get isOfficialPlugin(): true { return true; }
+					public static override get isPremiumPlugin(): false { return false; }
 				}
 			`,
 			options: [
@@ -89,15 +89,15 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 			code: `
 				class TestPlugin extends Plugin {
 					static get pluginName() { return 'TestPlugin'; }
-					public static get isOfficialPlugin(): true { return true; }
-					public static get isPremiumPlugin(): false { return false; }
-					public static get isNotOfficialPlugin(): false { return false; }
+					public static override get isOfficialPlugin(): true { return true; }
+					public static override get isPremiumPlugin(): false { return false; }
+					public static override get isNotOfficialPlugin(): false { return false; }
 				}
 			`,
 			output: `
 				class TestPlugin extends Plugin {
 					static get pluginName() { return 'TestPlugin'; }
-					public static get isPremiumPlugin(): false { return false; }
+					public static override get isPremiumPlugin(): false { return false; }
 				}
 			`,
 			options: [
@@ -117,18 +117,18 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 				class TestPlugin extends Plugin {
 					static get pluginName() { return 'TestPlugin'; }
 
-					public static get isOfficialPlugin(): true { return true; }
+					public static override get isOfficialPlugin(): true { return true; }
 
-					public static get isPremiumPlugin(): false { return false; }
+					public static override get isPremiumPlugin(): false { return false; }
 
-					public static get isNotOfficialPlugin(): false { return false; }
+					public static override get isNotOfficialPlugin(): false { return false; }
 				}
 			`,
 			output: `
 				class TestPlugin extends Plugin {
 					static get pluginName() { return 'TestPlugin'; }
 
-					public static get isPremiumPlugin(): false { return false; }
+					public static override get isPremiumPlugin(): false { return false; }
 				}
 			`,
 			options: [
@@ -156,14 +156,14 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 					/**
 					 * @inheritDoc
 					 */
-					public static get isOfficialPlugin(): true {
+					public static override get isOfficialPlugin(): true {
 						return true;
 					}
 
 					/**
 					 * @inheritDoc
 					 */
-					public static get isPremiumPlugin(): true {
+					public static override get isPremiumPlugin(): true {
 						return true;
 					}
 				}
@@ -193,8 +193,8 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 			code: `
 				class TestPlugin extends Plugin {
 					static get pluginName() { return 'TestPlugin'; }
-					public static get isOfficialPlugin(): false { return false; }
-					public static get isPremiumPlugin(): true { return true; }
+					public static override get isOfficialPlugin(): false { return false; }
+					public static override get isPremiumPlugin(): true { return true; }
 					public foo() {}
 				}
 			`,
@@ -205,14 +205,14 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 					/**
 					 * @inheritDoc
 					 */
-					public static get isOfficialPlugin(): true {
+					public static override get isOfficialPlugin(): true {
 						return true;
 					}
 
 					/**
 					 * @inheritDoc
 					 */
-					public static get isPremiumPlugin(): false {
+					public static override get isPremiumPlugin(): false {
 						return false;
 					}
 					public foo() {}
@@ -246,9 +246,9 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 				class TestPlugin extends Plugin {
 					static get pluginName() { return 'TestPlugin'; }
 
-					public static get isOfficialPlugin(): false { return false; }
+					public static override get isOfficialPlugin(): false { return false; }
 
-					public static get isPremiumPlugin(): true { return true; }
+					public static override get isPremiumPlugin(): true { return true; }
 				}
 			`,
 			output: `
@@ -258,14 +258,14 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 					/**
 					 * @inheritDoc
 					 */
-					public static get isOfficialPlugin(): true {
+					public static override get isOfficialPlugin(): true {
 						return true;
 					}
 
 					/**
 					 * @inheritDoc
 					 */
-					public static get isPremiumPlugin(): false {
+					public static override get isPremiumPlugin(): false {
 						return false;
 					}
 				}
@@ -298,7 +298,7 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 				class TestPlugin extends Plugin {
 					static get pluginName() { return 'TestPlugin'; }
 
-					public static get isOfficialPlugin(): true {
+					public static override get isOfficialPlugin(): true {
 						if ( true ) {
 							return true;
 						}
@@ -314,7 +314,7 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 					/**
 					 * @inheritDoc
 					 */
-					public static get isOfficialPlugin(): true {
+					public static override get isOfficialPlugin(): true {
 						return true;
 					}
 				}
@@ -350,7 +350,7 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 					/**
 					 * @inheritDoc
 					 */
-					public static get isOfficialPlugin(): true {
+					public static override get isOfficialPlugin(): true {
 						return true;
 					}
 				}
@@ -377,7 +377,7 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 					/**
 					 * @inheritDoc
 					 */
-					public static get isOfficialPlugin(): true {
+					public static override get isOfficialPlugin(): true {
 						return true;
 					}
 
@@ -391,7 +391,7 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 					/**
 					 * @inheritDoc
 					 */
-					public static get isOfficialPlugin(): true {
+					public static override get isOfficialPlugin(): true {
 						return true;
 					}
 				}
@@ -407,8 +407,7 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 				}
 			],
 			errors: [
-				{ messageId: 'definedBeforePluginName' },
-				{ messageId: 'definedInProperOrder' }
+				{ messageId: 'definedBeforePluginName' }
 			]
 		},
 
@@ -421,14 +420,14 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 					/**
 					 * @inheritDoc
 					 */
-					public static get isPremiumPlugin(): false {
+					public static override get isPremiumPlugin(): false {
 						return false;
 					}
 
 					/**
 					 * @inheritDoc
 					 */
-					public static get isOfficialPlugin(): true {
+					public static override get isOfficialPlugin(): true {
 						return true;
 					}
 				}
@@ -440,14 +439,14 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 					/**
 					 * @inheritDoc
 					 */
-					public static get isOfficialPlugin(): true {
+					public static override get isOfficialPlugin(): true {
 						return true;
 					}
 
 					/**
 					 * @inheritDoc
 					 */
-					public static get isPremiumPlugin(): false {
+					public static override get isPremiumPlugin(): false {
 						return false;
 					}
 				}
@@ -481,7 +480,7 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 					/**
 					 * @inheritDoc
 					 */
-					public static get isOfficialPlugin(): true {
+					public static override get isOfficialPlugin(): true {
 						return true;
 					}
 
@@ -492,7 +491,7 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 					/**
 					 * @inheritDoc
 					 */
-					public static get isPremiumPlugin(): false {
+					public static override get isPremiumPlugin(): false {
 						return false;
 					}
 				}
@@ -504,14 +503,14 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 					/**
 					 * @inheritDoc
 					 */
-					public static get isOfficialPlugin(): true {
+					public static override get isOfficialPlugin(): true {
 						return true;
 					}
 
 					/**
 					 * @inheritDoc
 					 */
-					public static get isPremiumPlugin(): false {
+					public static override get isPremiumPlugin(): false {
 						return false;
 					}
 

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/ckeditor-plugin-flags.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/ckeditor-plugin-flags.js
@@ -188,6 +188,62 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 			]
 		},
 
+		// Should properly recognize missing required flags on plugin that extends mixin.
+		{
+			code: `
+				class FormatPainterUI extends /* #__PURE__ -- @preserve */ DomEmitterMixin( Plugin ) {
+					/**
+					 * @inheritDoc
+					 */
+					public static get pluginName() {
+						return 'FormatPainterUI' as const;
+					}
+				}
+			`,
+			output: `
+				class FormatPainterUI extends /* #__PURE__ -- @preserve */ DomEmitterMixin( Plugin ) {
+					/**
+					 * @inheritDoc
+					 */
+					public static get pluginName() {
+						return 'FormatPainterUI' as const;
+					}
+
+					/**
+					 * @inheritDoc
+					 */
+					public static override get isOfficialPlugin(): true {
+						return true;
+					}
+
+					/**
+					 * @inheritDoc
+					 */
+					public static override get isPremiumPlugin(): true {
+						return true;
+					}
+				}
+			`,
+			options: [
+				{
+					requiredFlags: [
+						{
+							name: 'isOfficialPlugin',
+							returnValue: true
+						},
+						{
+							name: 'isPremiumPlugin',
+							returnValue: true
+						}
+					]
+				}
+			],
+			errors: [
+				{ messageId: 'missingRequiredFlag' },
+				{ messageId: 'missingRequiredFlag' }
+			]
+		},
+
 		// Should properly fix non spaced method definition when there are multiple required flags.
 		{
 			code: `

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/ckeditor-plugin-flags.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/ckeditor-plugin-flags.js
@@ -94,12 +94,6 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 					public static override get isNotOfficialPlugin(): false { return false; }
 				}
 			`,
-			output: `
-				class TestPlugin extends Plugin {
-					static get pluginName() { return 'TestPlugin'; }
-					public static override get isPremiumPlugin(): false { return false; }
-				}
-			`,
 			options: [
 				{
 					disallowedFlags: [ 'isOfficialPlugin', 'isNotOfficialPlugin' ]
@@ -124,13 +118,6 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 					public static override get isNotOfficialPlugin(): false { return false; }
 				}
 			`,
-			output: `
-				class TestPlugin extends Plugin {
-					static get pluginName() { return 'TestPlugin'; }
-
-					public static override get isPremiumPlugin(): false { return false; }
-				}
-			`,
 			options: [
 				{
 					disallowedFlags: [ 'isOfficialPlugin', 'isNotOfficialPlugin' ]
@@ -147,25 +134,6 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 			code: `
 				class TestNonPlugin extends Plugin {
 					static get pluginName() { return 'TestNonPlugin'; }
-				}
-			`,
-			output: `
-				class TestNonPlugin extends Plugin {
-					static get pluginName() { return 'TestNonPlugin'; }
-
-					/**
-					 * @inheritDoc
-					 */
-					public static override get isOfficialPlugin(): true {
-						return true;
-					}
-
-					/**
-					 * @inheritDoc
-					 */
-					public static override get isPremiumPlugin(): true {
-						return true;
-					}
 				}
 			`,
 			options: [
@@ -200,30 +168,6 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 					}
 				}
 			`,
-			output: `
-				class FormatPainterUI extends /* #__PURE__ -- @preserve */ DomEmitterMixin( Plugin ) {
-					/**
-					 * @inheritDoc
-					 */
-					public static get pluginName() {
-						return 'FormatPainterUI' as const;
-					}
-
-					/**
-					 * @inheritDoc
-					 */
-					public static override get isOfficialPlugin(): true {
-						return true;
-					}
-
-					/**
-					 * @inheritDoc
-					 */
-					public static override get isPremiumPlugin(): true {
-						return true;
-					}
-				}
-			`,
 			options: [
 				{
 					requiredFlags: [
@@ -244,58 +188,6 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 			]
 		},
 
-		// Should properly fix non spaced method definition when there are multiple required flags.
-		{
-			code: `
-				class TestPlugin extends Plugin {
-					static get pluginName() { return 'TestPlugin'; }
-					public static override get isOfficialPlugin(): false { return false; }
-					public static override get isPremiumPlugin(): true { return true; }
-					public foo() {}
-				}
-			`,
-			output: `
-				class TestPlugin extends Plugin {
-					static get pluginName() { return 'TestPlugin'; }
-
-					/**
-					 * @inheritDoc
-					 */
-					public static override get isOfficialPlugin(): true {
-						return true;
-					}
-
-					/**
-					 * @inheritDoc
-					 */
-					public static override get isPremiumPlugin(): false {
-						return false;
-					}
-					public foo() {}
-				}
-			`,
-			options: [
-				{
-					requiredFlags: [
-						{
-							name: 'isOfficialPlugin',
-							returnValue: true
-						},
-						{
-							name: 'isPremiumPlugin',
-							returnValue: false
-						}
-					]
-				}
-			],
-			errors: [
-				{ messageId: 'incorrectReturnValue' },
-				{ messageId: 'incorrectReturnLiteral' },
-				{ messageId: 'incorrectReturnValue' },
-				{ messageId: 'incorrectReturnLiteral' }
-			]
-		},
-
 		// Should raise error when plugin class has required flags with wrong return value.
 		{
 			code: `
@@ -307,25 +199,6 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 					public static override get isPremiumPlugin(): true { return true; }
 				}
 			`,
-			output: `
-				class TestPlugin extends Plugin {
-					static get pluginName() { return 'TestPlugin'; }
-
-					/**
-					 * @inheritDoc
-					 */
-					public static override get isOfficialPlugin(): true {
-						return true;
-					}
-
-					/**
-					 * @inheritDoc
-					 */
-					public static override get isPremiumPlugin(): false {
-						return false;
-					}
-				}
-			`,
 			options: [
 				{
 					requiredFlags: [
@@ -342,51 +215,7 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 			],
 			errors: [
 				{ messageId: 'incorrectReturnValue' },
-				{ messageId: 'incorrectReturnLiteral' },
-				{ messageId: 'incorrectReturnValue' },
-				{ messageId: 'incorrectReturnLiteral' }
-			]
-		},
-
-		// Should raise error if return value is not a single return statement.
-		{
-			code: `
-				class TestPlugin extends Plugin {
-					static get pluginName() { return 'TestPlugin'; }
-
-					public static override get isOfficialPlugin(): true {
-						if ( true ) {
-							return true;
-						}
-
-						return false;
-					}
-				}
-			`,
-			output: `
-				class TestPlugin extends Plugin {
-					static get pluginName() { return 'TestPlugin'; }
-
-					/**
-					 * @inheritDoc
-					 */
-					public static override get isOfficialPlugin(): true {
-						return true;
-					}
-				}
-			`,
-			options: [
-				{
-					requiredFlags: [
-						{
-							name: 'isOfficialPlugin',
-							returnValue: true
-						}
-					]
-				}
-			],
-			errors: [
-				{ messageId: 'singleReturnStatement' }
+				{ messageId: 'incorrectReturnValue' }
 			]
 		},
 
@@ -397,18 +226,6 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 					static get pluginName() { return 'TestPlugin'; }
 
 					private static get isOfficialPlugin(): true { return true; }
-				}
-			`,
-			output: `
-				class TestPlugin extends Plugin {
-					static get pluginName() { return 'TestPlugin'; }
-
-					/**
-					 * @inheritDoc
-					 */
-					public static override get isOfficialPlugin(): true {
-						return true;
-					}
 				}
 			`,
 			options: [
@@ -423,174 +240,6 @@ ruleTester.run( 'ckeditor-plugin-flags', require( '../../lib/rules/ckeditor-plug
 			],
 			errors: [
 				{ messageId: 'notPublicGetter' }
-			]
-		},
-
-		// Should raise error if flag is defined before pluginName.
-		{
-			code: `
-				class TestPlugin extends Plugin {
-					/**
-					 * @inheritDoc
-					 */
-					public static override get isOfficialPlugin(): true {
-						return true;
-					}
-
-					static get pluginName() { return 'TestPlugin'; }
-				}
-			`,
-			output: `
-				class TestPlugin extends Plugin {
-					static get pluginName() { return 'TestPlugin'; }
-
-					/**
-					 * @inheritDoc
-					 */
-					public static override get isOfficialPlugin(): true {
-						return true;
-					}
-				}
-			`,
-			options: [
-				{
-					requiredFlags: [
-						{
-							name: 'isOfficialPlugin',
-							returnValue: true
-						}
-					]
-				}
-			],
-			errors: [
-				{ messageId: 'definedBeforePluginName' }
-			]
-		},
-
-		// Should raise error if flags are not defined in proper order.
-		{
-			code: `
-				class TestPlugin extends Plugin {
-					static get pluginName() { return 'TestPlugin'; }
-
-					/**
-					 * @inheritDoc
-					 */
-					public static override get isPremiumPlugin(): false {
-						return false;
-					}
-
-					/**
-					 * @inheritDoc
-					 */
-					public static override get isOfficialPlugin(): true {
-						return true;
-					}
-				}
-			`,
-			output: `
-				class TestPlugin extends Plugin {
-					static get pluginName() { return 'TestPlugin'; }
-
-					/**
-					 * @inheritDoc
-					 */
-					public static override get isOfficialPlugin(): true {
-						return true;
-					}
-
-					/**
-					 * @inheritDoc
-					 */
-					public static override get isPremiumPlugin(): false {
-						return false;
-					}
-				}
-			`,
-			options: [
-				{
-					requiredFlags: [
-						{
-							name: 'isOfficialPlugin',
-							returnValue: true
-						},
-						{
-							name: 'isPremiumPlugin',
-							returnValue: false
-						}
-					]
-				}
-			],
-			errors: [
-				{ messageId: 'definedAfterSpecificMethod' },
-				{ messageId: 'definedAfterSpecificMethod' }
-			]
-		},
-
-		// Should raise error about incorrect flags order if there is constructor between flags.
-		{
-			code: `
-				class TestPlugin extends Plugin {
-					static get pluginName() { return 'TestPlugin'; }
-
-					/**
-					 * @inheritDoc
-					 */
-					public static override get isOfficialPlugin(): true {
-						return true;
-					}
-
-					constructor() {
-						super();
-					}
-
-					/**
-					 * @inheritDoc
-					 */
-					public static override get isPremiumPlugin(): false {
-						return false;
-					}
-				}
-			`,
-			output: `
-				class TestPlugin extends Plugin {
-					static get pluginName() { return 'TestPlugin'; }
-
-					/**
-					 * @inheritDoc
-					 */
-					public static override get isOfficialPlugin(): true {
-						return true;
-					}
-
-					/**
-					 * @inheritDoc
-					 */
-					public static override get isPremiumPlugin(): false {
-						return false;
-					}
-
-					constructor() {
-						super();
-					}
-				}
-			`,
-			options: [
-				{
-					requiredFlags: [
-						{
-							name: 'isOfficialPlugin',
-							returnValue: true
-						},
-						{
-							name: 'isPremiumPlugin',
-							returnValue: false
-						}
-					]
-				}
-			],
-			errors: [
-				{ messageId: 'definedInProperOrder' }
 			]
 		}
 	]


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (eslint-plugin-ckeditor5-rules): Add the `ckeditor5/ckeditor-plugin-flags` rule that disallows creating certain flags in plugins and enforces proper code style for allowed ones.

Fix (eslint-config-ckeditor5): Disallow defining `isOfficialPlugin` and `isPremiumPlugin` flags in plugins, restricting them to internal use only.

MINOR BREAKING CHANGE: Defining `isOfficialPlugin` and `isPremiumPlugin` flags in plugins is no longer allowed, as they are now restricted to internal use only.