### PR TITLE
Add the `allow-svg-imports-only-in-icons-package` rule

### DIFF
--- a/packages/eslint-plugin-ckeditor5-rules/lib/index.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/index.js
@@ -21,6 +21,7 @@ module.exports = {
 		'no-istanbul-in-debug-code': require( './rules/no-istanbul-in-debug-code' ),
 		'allow-declare-module-only-in-augmentation-file': require( './rules/allow-declare-module-only-in-augmentation-file' ),
 		'allow-imports-only-from-main-package-entry-point': require( './rules/allow-imports-only-from-main-package-entry-point.js' ),
+		'allow-svg-imports-only-in-icons-package': require( './rules/allow-svg-imports-only-in-icons-package.js' ),
 		'prevent-license-key-leak': require( './rules/prevent-license-key-leak' ),
 		'require-as-const-returns-in-methods': require( './rules/require-as-const-returns-in-methods' ),
 		'require-file-extensions-in-imports': require( './rules/require-file-extensions-in-imports' )

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-svg-imports-only-in-icons-package.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-svg-imports-only-in-icons-package.js
@@ -18,22 +18,16 @@ module.exports = {
 		}
 	},
 	create( { filename, report } ) {
+		if ( filename.includes( 'ckeditor5-icons' ) ) {
+			return {};
+		}
+
 		function validatePath( node ) {
-			const ignored = [
-				'docs',
-				'ckeditor5-icons'
-			];
-
-			if ( ignored.some( name => filename.includes( name ) ) ) {
-				return;
-			}
-
 			if ( !node.source ) {
 				return;
 			}
 
-			const url = node.source.value;
-			const extention = extname( url );
+			const extention = extname( node.source.value );
 
 			if ( !extention || extention !== '.svg' ) {
 				return;
@@ -41,7 +35,7 @@ module.exports = {
 
 			report( {
 				node,
-				message: 'SVG imports are only allowed in docs and the `@ckeditor/ckeditor5-icons` package.'
+				message: 'SVG imports are only allowed in the `@ckeditor/ckeditor5-icons` package.'
 			} );
 		}
 

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-svg-imports-only-in-icons-package.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-svg-imports-only-in-icons-package.js
@@ -1,0 +1,54 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const { extname } = require( 'upath' );
+
+module.exports = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Allow `.svg` imports only in the `@ckeditor/ckeditor5-icons` package',
+			category: 'CKEditor5',
+			// eslint-disable-next-line max-len
+			url: 'https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/code-style.html#svg-imports-only-in-the-ckeditorckeditor5-icons-package'
+		}
+	},
+	create( { filename, report } ) {
+		function validatePath( node ) {
+			const ignored = [
+				'docs',
+				'ckeditor5-icons'
+			];
+
+			if ( ignored.some( name => filename.includes( name ) ) ) {
+				return;
+			}
+
+			if ( !node.source ) {
+				return;
+			}
+
+			const url = node.source.value;
+			const extention = extname( url );
+
+			if ( !extention || extention !== '.svg' ) {
+				return;
+			}
+
+			report( {
+				node,
+				message: 'SVG imports are only allowed in docs and the `@ckeditor/ckeditor5-icons` package.'
+			} );
+		}
+
+		return {
+			ImportDeclaration: validatePath,
+			ExportAllDeclaration: validatePath,
+			ExportNamedDeclaration: validatePath
+		};
+	}
+};

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/allow-svg-imports-only-in-icons-package.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/allow-svg-imports-only-in-icons-package.js
@@ -17,10 +17,6 @@ ruleTester.run(
 	{
 		valid: [
 			{
-				code: 'import Icon from \'./icon.svg\';',
-				filename: '/some/docs/path/file.js'
-			},
-			{
 				code: 'export { default as Icon } from \'./icon.svg\';',
 				filename: '/packages/ckeditor5-icons/src/index.ts'
 			}
@@ -31,7 +27,7 @@ ruleTester.run(
 				filename: '/some/path/src/invalid.ts',
 				errors: [
 					{
-						message: 'SVG imports are only allowed in docs and the `@ckeditor/ckeditor5-icons` package.'
+						message: 'SVG imports are only allowed in the `@ckeditor/ckeditor5-icons` package.'
 					}
 				]
 			},
@@ -40,7 +36,7 @@ ruleTester.run(
 				filename: '/some/path/src/invalid.ts',
 				errors: [
 					{
-						message: 'SVG imports are only allowed in docs and the `@ckeditor/ckeditor5-icons` package.'
+						message: 'SVG imports are only allowed in the `@ckeditor/ckeditor5-icons` package.'
 					}
 				]
 			}

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/allow-svg-imports-only-in-icons-package.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/allow-svg-imports-only-in-icons-package.js
@@ -1,0 +1,49 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const RuleTester = require( 'eslint' ).RuleTester;
+
+const ruleTester = new RuleTester( {
+	parser: require.resolve( '@typescript-eslint/parser' )
+} );
+
+ruleTester.run(
+	'allow-declare-module-only-in-augmentation-file',
+	require( '../../lib/rules/allow-svg-imports-only-in-icons-package' ),
+	{
+		valid: [
+			{
+				code: 'import Icon from \'./icon.svg\';',
+				filename: '/some/docs/path/file.js'
+			},
+			{
+				code: 'export { default as Icon } from \'./icon.svg\';',
+				filename: '/packages/ckeditor5-icons/src/index.ts'
+			}
+		],
+		invalid: [
+			{
+				code: 'import Icon from \'./icon.svg\';',
+				filename: '/some/path/src/invalid.ts',
+				errors: [
+					{
+						message: 'SVG imports are only allowed in docs and the `@ckeditor/ckeditor5-icons` package.'
+					}
+				]
+			},
+			{
+				code: 'export { default as Icon } from \'./icon.svg\';',
+				filename: '/some/path/src/invalid.ts',
+				errors: [
+					{
+						message: 'SVG imports are only allowed in docs and the `@ckeditor/ckeditor5-icons` package.'
+					}
+				]
+			}
+		]
+	}
+);


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Feature (eslint-plugin-ckeditor5-rules): Add the `allow-svg-imports-only-in-icons-package` rule.

---

Related to ckeditor/ckeditor5#16546.
