### PR TITLE
Added `dryRun` parameter to `commitAndTag()` function to run commit validations during a release

### DIFF
--- a/scripts/preparepackages.mjs
+++ b/scripts/preparepackages.mjs
@@ -136,19 +136,12 @@ const tasks = new Listr( [
 		task: () => {
 			return releaseTools.commitAndTag( {
 				version: latestVersion,
+				dryRun: cliArguments.compileOnly,
 				files: [
 					'package.json',
 					`${ PACKAGES_DIRECTORY }/*/package.json`
 				]
 			} );
-		},
-		skip: () => {
-			// When compiling the packages only, do not validate the release.
-			if ( cliArguments.compileOnly ) {
-				return true;
-			}
-
-			return false;
 		}
 	}
 ], getListrOptions( cliArguments ) );


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Added `dryRun` parameter to `commitAndTag()` function to run commit validations during a release.

---

### Additional information

⚠️ Depends on https://github.com/ckeditor/ckeditor5-dev/pull/1077.
