### PR TITLE
Temporarily enabled npm releases from an epic branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ commands:
             CKE5_GITHUB_ORGANIZATION="ckeditor"
             CKE5_GITHUB_REPOSITORY="ckeditor5-linters-config"
             CKE5_CIRCLE_APPROVAL_JOB_NAME="release_approval"
-            CKE5_GITHUB_RELEASE_BRANCH="master"
+            CKE5_GITHUB_RELEASE_BRANCH="epic/ck/18475-eslint9"
 
             echo export CKE5_CIRCLE_APPROVAL_JOB_NAME=$CKE5_CIRCLE_APPROVAL_JOB_NAME >> $BASH_ENV
             echo export CKE5_GITHUB_RELEASE_BRANCH=$CKE5_GITHUB_RELEASE_BRANCH >> $BASH_ENV
@@ -126,7 +126,7 @@ jobs:
       - bootstrap_repository_command
       - run:
           name: Check if packages are ready to be released
-          command: yarn run release:prepare-packages --verbose --compile-only
+          command: yarn run release:prepare-packages --verbose --compile-only --branch=epic/ck/18475-eslint9
 
   trigger_release_process:
     machine: true
@@ -162,11 +162,11 @@ jobs:
           command: |
             #!/bin/bash
 
-            CKE5_LATEST_COMMIT_HASH=$( git log -n 1 --pretty=format:%H origin/master )
+            CKE5_LATEST_COMMIT_HASH=$( git log -n 1 --pretty=format:%H origin/epic/ck/18475-eslint9 )
             CKE5_TRIGGER_COMMIT_HASH=<< pipeline.parameters.triggerCommitHash >>
 
             if [[ "${CKE5_LATEST_COMMIT_HASH}" != "${CKE5_TRIGGER_COMMIT_HASH}" ]]; then
-              echo "There is a newer commit in the repository on the \`#master\` branch. Use its build to start the release."
+              echo "There is a newer commit in the repository on the \`#epic/ck/18475-eslint9\` branch. Use its build to start the release."
               circleci-agent step halt
             fi
       - npm_login_command
@@ -192,10 +192,10 @@ jobs:
           command: yarn ckeditor5-dev-ci-circle-disable-auto-cancel-builds
       - run:
           name: Prepare the new version to release
-          command: npm run release:prepare-packages -- --verbose
+          command: npm run release:prepare-packages -- --verbose --branch=epic/ck/18475-eslint9
       - run:
           name: Publish the packages
-          command: npm run release:publish-packages -- --verbose
+          command: npm run release:publish-packages -- --verbose --branch=epic/ck/18475-eslint9
       - run:
           name: Enable the redundant workflows option
           command: yarn ckeditor5-dev-ci-circle-enable-auto-cancel-builds
@@ -226,7 +226,7 @@ workflows:
           filters:
             branches:
               only:
-                - master
+                - epic/ck/18475-eslint9
       - notify_ci_failure:
           filters:
             branches:

--- a/packages/eslint-config-ckeditor5/package.json
+++ b/packages/eslint-config-ckeditor5/package.json
@@ -19,6 +19,9 @@
     "eslint.config.mjs",
     "CHANGELOG.md"
   ],
+  "engines": {
+    "node": ">=22.0.0"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/ckeditor/ckeditor5-linters-config.git",


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Internal: Temporarily enabled npm releases from an epic branch `epic/ck/18475-eslint9`. Closes ckeditor/ckeditor5#18498.

Internal: Set the minimal Node version for `eslint-config-ckeditor5` package to match the ESLint v9.x requirement.

---

### Additional information

I set the minimal Node version only for `eslint-config-ckeditor5` package, because only this package defines a requirement on ESLint v9.x. The `eslint-plugin-ckeditor5-rules` can be still used with earlier ESLint versions.
