### PR TITLE
Updated eslint config

### DIFF
--- a/packages/eslint-config-ckeditor5/eslint.config.mjs
+++ b/packages/eslint-config-ckeditor5/eslint.config.mjs
@@ -292,7 +292,7 @@ const rulesTypeScript = [
 			}
 		},
 
-		extends: [ 'ts/recommendedTypeChecked' ],
+		extends: [ 'ts/recommended' ],
 
 		files: [ '**/*.@(ts|tsx)' ],
 
@@ -307,45 +307,7 @@ const rulesTypeScript = [
 				default: 'generic'
 			} ],
 
-			'@typescript-eslint/await-thenable': 'off',
-
-			'@typescript-eslint/no-base-to-string': 'off',
-
-			'@typescript-eslint/no-duplicate-type-constituents': 'off',
-
-			'@typescript-eslint/no-floating-promises': 'off',
-
-			'@typescript-eslint/no-misused-promises': 'off',
-
-			'@typescript-eslint/no-redundant-type-constituents': 'off',
-
-			'@typescript-eslint/no-unnecessary-type-assertion': 'off',
-
-			'@typescript-eslint/no-unsafe-argument': 'off',
-
-			'@typescript-eslint/no-unsafe-assignment': 'off',
-
-			'@typescript-eslint/no-unsafe-call': 'off',
-
 			'@typescript-eslint/no-unsafe-function-type': 'off',
-
-			'@typescript-eslint/no-unsafe-member-access': 'off',
-
-			'@typescript-eslint/no-unsafe-return': 'off',
-
-			'@typescript-eslint/only-throw-error': 'off',
-
-			'@typescript-eslint/prefer-promise-reject-errors': 'off',
-
-			'@typescript-eslint/require-await': 'off',
-
-			'@typescript-eslint/restrict-plus-operands': 'off',
-
-			'@typescript-eslint/restrict-template-expressions': 'off',
-
-			'@typescript-eslint/unbound-method': 'off',
-
-			'@typescript-eslint/no-for-in-array': 'off',
 
 			'@typescript-eslint/no-empty-object-type': 'error',
 

--- a/packages/eslint-config-ckeditor5/eslint.config.mjs
+++ b/packages/eslint-config-ckeditor5/eslint.config.mjs
@@ -285,12 +285,6 @@ const rulesTypeScript = [
 			ts
 		},
 
-		languageOptions: {
-			parserOptions: {
-				projectService: true
-			}
-		},
-
 		extends: [ 'ts/recommended' ],
 
 		files: [ '**/*.@(ts|tsx)' ],
@@ -320,8 +314,6 @@ const rulesTypeScript = [
 			'@typescript-eslint/consistent-type-imports': [ 'error', {
 				fixStyle: 'inline-type-imports'
 			} ],
-
-			'@typescript-eslint/consistent-type-exports': 'error',
 
 			'@typescript-eslint/explicit-module-boundary-types': [ 'error', {
 				allowedNames: [ 'requires', 'pluginName' ],

--- a/packages/eslint-config-ckeditor5/eslint.config.mjs
+++ b/packages/eslint-config-ckeditor5/eslint.config.mjs
@@ -285,7 +285,14 @@ const rulesTypeScript = [
 			ts
 		},
 
-		extends: [ 'ts/recommended' ],
+		languageOptions: {
+			parserOptions: {
+				projectService: true,
+				tsconfigRootDir: import.meta.dirname
+			}
+		},
+
+		extends: [ 'ts/recommendedTypeChecked' ],
 
 		files: [ '**/*.@(ts|tsx)' ],
 
@@ -300,7 +307,45 @@ const rulesTypeScript = [
 				default: 'generic'
 			} ],
 
+			'@typescript-eslint/await-thenable': 'off',
+
+			'@typescript-eslint/no-base-to-string': 'off',
+
+			'@typescript-eslint/no-duplicate-type-constituents': 'off',
+
+			'@typescript-eslint/no-floating-promises': 'off',
+
+			'@typescript-eslint/no-misused-promises': 'off',
+
+			'@typescript-eslint/no-redundant-type-constituents': 'off',
+
+			'@typescript-eslint/no-unnecessary-type-assertion': 'off',
+
+			'@typescript-eslint/no-unsafe-argument': 'off',
+
+			'@typescript-eslint/no-unsafe-assignment': 'off',
+
+			'@typescript-eslint/no-unsafe-call': 'off',
+
 			'@typescript-eslint/no-unsafe-function-type': 'off',
+
+			'@typescript-eslint/no-unsafe-member-access': 'off',
+
+			'@typescript-eslint/no-unsafe-return': 'off',
+
+			'@typescript-eslint/only-throw-error': 'off',
+
+			'@typescript-eslint/prefer-promise-reject-errors': 'off',
+
+			'@typescript-eslint/require-await': 'off',
+
+			'@typescript-eslint/restrict-plus-operands': 'off',
+
+			'@typescript-eslint/restrict-template-expressions': 'off',
+
+			'@typescript-eslint/unbound-method': 'off',
+
+			'@typescript-eslint/no-for-in-array': 'off',
 
 			'@typescript-eslint/no-empty-object-type': 'error',
 
@@ -311,7 +356,11 @@ const rulesTypeScript = [
 				objectLiteralTypeAssertions: 'allow-as-parameter'
 			} ],
 
-			'@typescript-eslint/consistent-type-imports': 'error',
+			'@typescript-eslint/consistent-type-imports': [ 'error', {
+				fixStyle: 'inline-type-imports'
+			} ],
+
+			'@typescript-eslint/consistent-type-exports': 'error',
 
 			'@typescript-eslint/explicit-module-boundary-types': [ 'error', {
 				allowedNames: [ 'requires', 'pluginName' ],

--- a/packages/eslint-config-ckeditor5/eslint.config.mjs
+++ b/packages/eslint-config-ckeditor5/eslint.config.mjs
@@ -287,8 +287,7 @@ const rulesTypeScript = [
 
 		languageOptions: {
 			parserOptions: {
-				projectService: true,
-				tsconfigRootDir: import.meta.dirname
+				projectService: true
 			}
 		},
 


### PR DESCRIPTION
### Suggested merge commit message ([convention](https://github.com/ckeditor/ckeditor5-design/wiki/Git-commit-message-convention))

Other: Updated autofixer for `@typescript-eslint/consistent-type-imports` eslint rule. It will now automatically add the `type` keyword in the same import, instead of creating new one, which would cause `duplicate-import` error. Closes ckeditor/ckeditor5#18535
