### PR TITLE
Added variable name rule

### DIFF
--- a/.changelog/20250708175532_ck_18805.md
+++ b/.changelog/20250708175532_ck_18805.md
@@ -1,0 +1,45 @@
+---
+# Required: Type of change.
+# Allowed values:
+# - Feature
+# - Fix
+# - Other
+# - Major breaking change
+# - Minor breaking change
+#
+# For guidance on breaking changes, see:
+# https://ckeditor.com/docs/ckeditor5/latest/updating/versioning-policy.html#major-and-minor-breaking-changes
+type: Major breaking change
+
+# Optional: Affected package(s), using short names.
+# Can be skipped when processing a non-mono-repository.
+# Example: ckeditor5-core
+scope:
+  - 
+
+# Optional: Issues this change closes.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/18805
+
+# Optional: Related issues.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+see:
+  - 
+
+# Optional: Community contributors.
+# Format:
+# - {github-username}
+communityCredits:
+  - 
+
+# Before committing, consider removing all comments to reduce file size and enhance readability.
+---
+
+Added new rule: `ckeditor5-rules/ck-content-variable-name`. It enforces all variables used inside `.ck-content` selectors to have the `--ck-content` prefix.

--- a/packages/stylelint-config-ckeditor5/.stylelintrc
+++ b/packages/stylelint-config-ckeditor5/.stylelintrc
@@ -2,9 +2,11 @@
 	"extends": "stylelint-config-recommended",
 	"plugins": [
 		"@stylistic/stylelint-plugin",
+		"stylelint-plugin-ckeditor5-rules/lib/ck-content-variable-name",
 		"stylelint-plugin-ckeditor5-rules/lib/license-header"
 	],
 	"rules": {
+		"ckeditor5-rules/ck-content-variable-name": false,
 		"at-rule-no-unknown": null,
 		"@stylistic/indentation": "tab",
 		"declaration-property-value-disallowed-list": {

--- a/packages/stylelint-config-ckeditor5/.stylelintrc
+++ b/packages/stylelint-config-ckeditor5/.stylelintrc
@@ -6,7 +6,7 @@
 		"stylelint-plugin-ckeditor5-rules/lib/license-header"
 	],
 	"rules": {
-		"ckeditor5-rules/ck-content-variable-name": false,
+		"ckeditor5-rules/ck-content-variable-name": true,
 		"at-rule-no-unknown": null,
 		"@stylistic/indentation": "tab",
 		"declaration-property-value-disallowed-list": {

--- a/packages/stylelint-plugin-ckeditor5-rules/lib/ck-content-variable-name.js
+++ b/packages/stylelint-plugin-ckeditor5-rules/lib/ck-content-variable-name.js
@@ -4,7 +4,7 @@
  */
 
 const SELECTOR = '.ck-content';
-const PREFIX = '--ck-content';
+const PREFIX = '--ck-content-';
 
 const stylelint = require( 'stylelint' );
 
@@ -12,7 +12,7 @@ const { report, ruleMessages } = stylelint.utils;
 
 const ruleName = 'ckeditor5-rules/ck-content-variable-name';
 const messages = ruleMessages( ruleName, {
-	invalidSelector: `Variables inside the '${ SELECTOR }' selector have to use the '${ PREFIX }-*' prefix.`
+	invalidSelector: `Variables inside the '${ SELECTOR }' selector have to use the '${ PREFIX }*' prefix.`
 } );
 
 module.exports.ruleName = ruleName;

--- a/packages/stylelint-plugin-ckeditor5-rules/lib/ck-content-variable-name.js
+++ b/packages/stylelint-plugin-ckeditor5-rules/lib/ck-content-variable-name.js
@@ -1,0 +1,56 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+const SELECTOR = '.ck-content';
+const PREFIX = '--ck-content';
+
+const stylelint = require( 'stylelint' );
+
+const { report, ruleMessages } = stylelint.utils;
+
+const ruleName = 'ckeditor5-rules/ck-content-variable-name';
+const messages = ruleMessages( ruleName, {
+	invalidSelector: `Variables inside the '${ SELECTOR }' selector have to use the '${ PREFIX }-*' prefix.`
+} );
+
+module.exports.ruleName = ruleName;
+module.exports.messages = messages;
+
+module.exports = stylelint.createPlugin( ruleName, () => {
+	return ( root, result ) => parseNodes( result, root.nodes );
+} );
+
+function parseNodes( result, nodes = [], isInsideMatchingSelector = false ) {
+	nodes.forEach( node => {
+		parseNodes(
+			result,
+			node.nodes,
+			isInsideMatchingSelector || node.selector?.includes( SELECTOR )
+		);
+
+		if ( !isInsideMatchingSelector ) {
+			return;
+		}
+
+		if ( node.type !== 'decl' ) {
+			return;
+		}
+
+		if ( !node.value.startsWith( 'var(' ) ) {
+			return;
+		}
+
+		if ( node.value.startsWith( 'var(' + PREFIX ) ) {
+			return;
+		}
+
+		report( {
+			message: messages.invalidSelector,
+			ruleName,
+			result,
+			node
+		} );
+	} );
+}

--- a/packages/stylelint-plugin-ckeditor5-rules/tests/ck-content-variable-name.js
+++ b/packages/stylelint-plugin-ckeditor5-rules/tests/ck-content-variable-name.js
@@ -1,0 +1,166 @@
+/**
+ * @license Copyright (c) 2003-2025, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const { getTestRule } = require( 'jest-preset-stylelint' );
+const upath = require( 'upath' );
+const util = require( 'util' );
+
+const PLUGIN_PATH = upath.join( __dirname, '..', 'lib', 'ck-content-variable-name.js' );
+
+global.testRule = getTestRule();
+
+const config = [
+	true
+];
+
+const { ruleName } = require( PLUGIN_PATH );
+
+const message = [
+	'Variables inside the \'.ck-content\' selector have to use the \'--ck-content-*\' prefix.',
+	'(ckeditor5-rules/ck-content-variable-name)'
+].join( ' ' );
+
+// For reasons that we don't understand, the `jest-preset-stylelint` package created additional `describe()` blocks for
+// the plugin configuration and the checked code. It uses the `util.inspect()` function for making a string from the given `input`.
+// Lets override it and return an empty string for these values to avoid a mess in a console.
+// The original function is restored at the end of the file.
+const defaultInspectFunction = util.inspect;
+
+util.inspect = input => {
+	// To hide empty input.
+	if ( !input ) {
+		return '';
+	}
+
+	// To hide: https://github.com/stylelint/jest-preset-stylelint/blob/3606955a27a22be789b9372b5dafaaab25401f7f/getTestRule.js#L172.
+	if ( input === config ) {
+		return '';
+	}
+
+	// To hide: https://github.com/stylelint/jest-preset-stylelint/blob/3606955a27a22be789b9372b5dafaaab25401f7f/getTestRule.js#L173.
+	const stringsToHide = [ 'CKSource Holding', '.ck.ck-editor' ];
+	const shouldHide = stringsToHide.some( string => input.includes( string ) );
+
+	if ( shouldHide ) {
+		return '';
+	}
+
+	// In all other cases, function should function normally.
+	return defaultInspectFunction( input );
+};
+
+global.testRule( {
+	plugins: [ PLUGIN_PATH ],
+	ruleName,
+	config,
+
+	accept: [
+		{
+			description: 'An empty file.',
+			code: ''
+		},
+		{
+			description: 'File containing unrelated selector using any variable.',
+			code: [
+				'.generic-selector {',
+				'	width: var(--variable-name);',
+				'}',
+				''
+			].join( '\n' )
+		},
+		{
+			description: 'File containing the ".ck-content" selector not using variables.',
+			code: [
+				'.ck-content {',
+				'	width: 50px;',
+				'}',
+				''
+			].join( '\n' )
+		},
+		{
+			description: 'File containing the ".ck-content" selector using valid variable name.',
+			code: [
+				'.ck-content {',
+				'	width: var(--ck-content-variable-name);',
+				'}',
+				''
+			].join( '\n' )
+		},
+		{
+			description: 'File containing the ".ck-content" selector with nested selectors using valid variable name.',
+			code: [
+				'.ck-content {',
+				'	.generic-selector {',
+				'		width: var(--ck-content-variable-name);',
+				'	}',
+				'}',
+				''
+			].join( '\n' )
+		},
+		{
+			description: 'File containing nested ".ck-content" selector using valid variable name.',
+			code: [
+				'.generic-selector {',
+				'	.ck-content {',
+				'		width: var(--ck-content-variable-name);',
+				'	}',
+				'}',
+				''
+			].join( '\n' )
+		}
+	],
+
+	reject: [
+		{
+			description: 'File containing the ".ck-content" selector using invalid variable name.',
+			message,
+			code: [
+				'.ck-content {',
+				'	width: var(--variable-name);',
+				'}',
+				''
+			].join( '\n' )
+		},
+		{
+			description: 'File containing the ".ck-content" selector combined with other selectors using invalid variable name.',
+			message,
+			code: [
+				'.generic-selector.ck-content {',
+				'	width: var(--variable-name);',
+				'}',
+				''
+			].join( '\n' )
+		},
+		{
+			description: 'File containing the ".ck-content" selector with nested selectors using invalid variable name.',
+			message,
+			code: [
+				'.ck-content {',
+				'	.generic-selector {',
+				'		width: var(--variable-name);',
+				'	}',
+				'}',
+				''
+			].join( '\n' )
+		},
+		{
+			description: 'File containing nested ".ck-content" selector using invalid variable name.',
+			message,
+			code: [
+				'.generic-selector {',
+				'	.ck-content {',
+				'		width: var(--variable-name);',
+				'	}',
+				'}',
+				''
+			].join( '\n' )
+		}
+	]
+} );
+
+// Restore the original function.
+util.inspect = defaultInspectFunction;


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn run nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Added new rule: `ckeditor5-rules/ck-content-variable-name`. It enforces all variables used inside `.ck-content` selectors to have the `--ck-content` prefix.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes ckeditor/ckeditor5#18805

---

### 💡 Additional information

Marked in the changeset as BC now, because I've added it to the default config. IMO it makes sense, as any repo that defines the `.ck-content` selector anywhere, should follow the rule.
