### PR TITLE
[v11] The general ESLint rules should also match `.cjs` and `.mts` files.

### DIFF
--- a/.changelog/20250710153358_core_18839_fix_failing_ci.md
+++ b/.changelog/20250710153358_core_18839_fix_failing_ci.md
@@ -1,0 +1,7 @@
+---
+type: Fix
+scope: eslint-config-ckeditor5
+closes: https://github.com/ckeditor/ckeditor5/issues/18839
+---
+
+The general ESLint rules should also match `.cjs` and `.mts` files.

--- a/packages/eslint-config-ckeditor5/eslint.config.mjs
+++ b/packages/eslint-config-ckeditor5/eslint.config.mjs
@@ -25,8 +25,8 @@ const rulesGeneral = [
 			ecmaVersion: 2020,
 			sourceType: 'module'
 		},
-		
-		files: [ '**/*.@(js|ts|tsx)' ],
+
+		files: [ '**/*.@(js|cjs|mjs|ts|tsx)' ],
 
 		rules: {
 			/*

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/validate-changelog-entry.mjs
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/validate-changelog-entry.mjs
@@ -323,7 +323,7 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/validate-changelog-entry', rule, 
 			Change summary.
 			`,
 			options: [ { repositoryType: 'mono' } ]
-		},
+		}
 	],
 
 	invalid: [
@@ -523,6 +523,6 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/validate-changelog-entry', rule, 
 			errors: [
 				'Invalid \'communityCredits\' value: \'%^&*\'.'
 			]
-		},
+		}
 	]
 } );


### PR DESCRIPTION
### 🚀 Summary

[Backport] The general ESLint rules should also match `.cjs` and `.mts` files.

### 📌 Related issues

* See #74
