### PR TITLE
Added a fixer for the `ckeditor5-rules/allow-imports-only-from-main-package-entry-point` rule

### DIFF
--- a/.changelog/20250722140239_ck_18857.md
+++ b/.changelog/20250722140239_ck_18857.md
@@ -1,0 +1,45 @@
+---
+# Required: Type of change.
+# Allowed values:
+# - Feature
+# - Fix
+# - Other
+# - Major breaking change
+# - Minor breaking change
+#
+# For guidance on breaking changes, see:
+# https://ckeditor.com/docs/ckeditor5/latest/updating/versioning-policy.html#major-and-minor-breaking-changes
+type: Feature
+
+# Optional: Affected package(s), using short names.
+# Can be skipped when processing a non-mono-repository.
+# Example: ckeditor5-core
+scope:
+  - eslint-plugin-ckeditor5-rules
+
+# Optional: Issues this change closes.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/18857
+
+# Optional: Related issues.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+see:
+  - 
+
+# Optional: Community contributors.
+# Format:
+# - {github-username}
+communityCredits:
+  - 
+
+# Before committing, consider removing all comments to reduce file size and enhance readability.
+---
+
+Added code fixer for `ckeditor5-rules/allow-imports-only-from-main-package-entry-point`.

--- a/.changelog/20250722145646_ck_18857.md
+++ b/.changelog/20250722145646_ck_18857.md
@@ -1,0 +1,45 @@
+---
+# Required: Type of change.
+# Allowed values:
+# - Feature
+# - Fix
+# - Other
+# - Major breaking change
+# - Minor breaking change
+#
+# For guidance on breaking changes, see:
+# https://ckeditor.com/docs/ckeditor5/latest/updating/versioning-policy.html#major-and-minor-breaking-changes
+type: Fix
+
+# Optional: Affected package(s), using short names.
+# Can be skipped when processing a non-mono-repository.
+# Example: ckeditor5-core
+scope:
+  - eslint-plugin-ckeditor5-rules
+
+# Optional: Issues this change closes.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+closes:
+  - 
+
+# Optional: Related issues.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+see:
+  - 
+
+# Optional: Community contributors.
+# Format:
+# - {github-username}
+communityCredits:
+  - 
+
+# Before committing, consider removing all comments to reduce file size and enhance readability.
+---
+
+Fixed the `ckeditor5-rules/ckeditor-imports` rule detecting errors for imports that do not start with `ckeditor5`.

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-imports-only-from-main-package-entry-point.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-imports-only-from-main-package-entry-point.js
@@ -31,7 +31,7 @@ module.exports = {
 				const match = path.match( /@ckeditor\/[^/]+/ );
 
 				if ( !match ) {
-					// Ignore imports that do not match the with '@ckeditor/package-name' pattern.
+					// Ignore imports that do not match with the '@ckeditor/package-name' pattern.
 					return;
 				}
 

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-imports-only-from-main-package-entry-point.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-imports-only-from-main-package-entry-point.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+const message = 'Importing from "@ckeditor/*" packages is only allowed from the main package entry point.';
+
 module.exports = {
 	meta: {
 		type: 'problem',
@@ -14,6 +16,7 @@ module.exports = {
 			// eslint-disable-next-line @stylistic/max-len
 			url: 'https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/code-style.html#importing-from-modules-ckeditor5-rulesallow-imports-only-from-main-package-entry-point'
 		},
+		fixable: 'code',
 		schema: []
 	},
 	create( context ) {
@@ -25,20 +28,40 @@ module.exports = {
 				}
 
 				const path = node.source.value;
+				const match = path.match( /@ckeditor\/[^/]+/ );
 
-				if ( !path.startsWith( '@ckeditor/' ) ) {
-					// Ignore imports that do not start with '@ckeditor/'.
+				if ( !match ) {
+					// Ignore imports that do not match the with '@ckeditor/package-name' pattern.
 					return;
 				}
 
-				if ( path.split( '/' ).length === 2 ) {
+				if ( path === match[ 0 ] ) {
 					// Ignore imports from the main package entry point.
 					return;
 				}
 
+				const defaultImport = node.specifiers.find( item => item.type === 'ImportDefaultSpecifier' );
+				const namedImport = node.specifiers.find( item => item.type === 'ImportSpecifier' );
+
+				// If import uses both default and named imports, we don't know how to fix it.
+				if ( defaultImport && namedImport ) {
+					return context.report( { node, message } );
+				}
+
 				context.report( {
 					node,
-					message: 'Importing from "@ckeditor/*" packages is only allowed from the main package entry point.'
+					message,
+					fix: fixer => {
+						const fixes = [
+							fixer.replaceTextRange( node.source.range, `'${ match[ 0 ] }'` )
+						];
+
+						if ( defaultImport ) {
+							fixes.push( fixer.replaceTextRange( defaultImport.range, `{ ${ defaultImport.local.name } }` ) );
+						}
+
+						return fixes;
+					}
 				} );
 			}
 		};

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/ckeditor-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/ckeditor-imports.js
@@ -14,7 +14,7 @@ const SHORT_PACKAGE_NAME_IMPORT_REGEXP = /@ckeditor\/ckeditor5?-([^/]+)/;
 const SHORT_PACKAGE_NAME_PATH_REGEXP = /ckeditor5?-([^/\\]+)/;
 
 // A regular expression for determining whether an imported path uses the `src/` directory.
-const CKEDITOR5_PACKAGE_IMPORT_REGEXP = /ckeditor5\/(?!src)/;
+const CKEDITOR5_PACKAGE_IMPORT_REGEXP = /^ckeditor5\/(?!src)/;
 
 // A regular expression for determining the short package name when importing using the `ckeditor5` package.
 const CKEDITOR5_SHORT_PACKAGE_NAME_REGEXP = /ckeditor5\/src\/(.*)/;

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/allow-imports-only-from-main-package-entry-point.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/allow-imports-only-from-main-package-entry-point.js
@@ -5,6 +5,8 @@
 
 'use strict';
 
+const message = 'Importing from "@ckeditor/*" packages is only allowed from the main package entry point.';
+
 const RuleTester = require( 'eslint' ).RuleTester;
 
 const ruleTester = new RuleTester( {
@@ -19,35 +21,33 @@ ruleTester.run(
 	require( '../../lib/rules/allow-imports-only-from-main-package-entry-point.js' ),
 	{
 		valid: [
-			'import { Table } from "@ckeditor/ckeditor5-table";'
+			'import Foo from \'Foo\';',
+			'import Foo from \'ckeditor5-foo/bar/baz.js\';',
+			'import { Table } from \'@ckeditor/ckeditor5-table\';'
 		],
 		invalid: [
 			// Do not allow importing from the `src` folder.
 			{
 				code: 'import Table from "@ckeditor/ckeditor5-table/src/table";',
-				errors: [
-					{
-						message: 'Importing from "@ckeditor/*" packages is only allowed from the main package entry point.'
-					}
-				]
+				output: 'import { Table } from \'@ckeditor/ckeditor5-table\';',
+				errors: [ { message } ]
 			},
 			// Do not allow importing icons from the `theme` folder.
 			{
 				code: 'import icon from "@ckeditor/ckeditor5-table/theme/icons/icon.svg";',
-				errors: [
-					{
-						message: 'Importing from "@ckeditor/*" packages is only allowed from the main package entry point.'
-					}
-				]
+				output: 'import { icon } from \'@ckeditor/ckeditor5-table\';',
+				errors: [ { message } ]
 			},
 			// Do not allow importing style sheets from the `theme` folder.
 			{
 				code: 'import styles from "@ckeditor/ckeditor5-table/theme/styles.css";',
-				errors: [
-					{
-						message: 'Importing from "@ckeditor/*" packages is only allowed from the main package entry point.'
-					}
-				]
+				output: 'import { styles } from \'@ckeditor/ckeditor5-table\';',
+				errors: [ { message } ]
+			},
+			// Do not fix if there are both default and named imports.
+			{
+				code: 'import Foo, { Bar } from "@ckeditor/ckeditor5-core/src/core";',
+				errors: [ { message } ]
 			}
 		]
 	}

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/ckeditor-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/ckeditor-imports.js
@@ -39,6 +39,9 @@ const ruleTester = new RuleTester( {
 
 ruleTester.run( 'eslint-plugin-ckeditor5-rules/ckeditor-imports', ckeditorImports, {
 	valid: [
+		// Imports not starting with `ckeditor5`.
+		'import ckeditor5Config from \'./external/ckeditor5/eslint.config.mjs\';',
+
 		// Expected imports.
 		'import { Plugin } from \'ckeditor5/src/core\';',
 		'import { first, last } from \'ckeditor5/src/utils\';',


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    yarn run nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

 - Added a fixer for the `ckeditor5-rules/allow-imports-only-from-main-package-entry-point` rule
 - Fixed the `ckeditor5-rules/ckeditor-imports` rule detecting errors for imports that do not start with `ckeditor5`.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes https://github.com/ckeditor/ckeditor5/issues/18857

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
