### PR TITLE
Changeset indent validation

### DIFF
--- a/.changelog/20250929114234_ck_19026.md
+++ b/.changelog/20250929114234_ck_19026.md
@@ -1,0 +1,45 @@
+---
+# Required: Type of change.
+# Allowed values:
+# - Feature
+# - Fix
+# - Other
+# - Major breaking change
+# - Minor breaking change
+#
+# For guidance on breaking changes, see:
+# https://ckeditor.com/docs/ckeditor5/latest/updating/versioning-policy.html#major-and-minor-breaking-changes
+type: Feature
+
+# Optional: Affected package(s), using short names.
+# Leave empty when used in a single-package repository.
+# Example: ckeditor5-core
+scope:
+  - eslint-plugin-ckeditor5-rules
+
+# Optional: Issues this change closes.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/19026
+
+# Optional: Related issues.
+# Format:
+# - {issue-number}
+# - {repo-owner}/{repo-name}#{issue-number}
+# - Full GitHub URL
+see:
+  - 
+
+# Optional: Community contributors.
+# Format:
+# - {github-username}
+communityCredits:
+  - 
+
+# Before committing, consider removing all comments to reduce file size and enhance readability.
+---
+
+Added validation to ensure that changeset files are indented using spaces instead of tabs.

--- a/package.json
+++ b/package.json
@@ -51,8 +51,5 @@
     "**/*.{js,mjs}": [
       "eslint --quiet"
     ]
-  },
-  "dependencies": {
-    "eslint-plugin-yml": "^1.18.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "scripts": {
     "nice": "ckeditor5-dev-changelog-create-entry",
     "postinstall": "node ./scripts/postinstall.mjs",
-    "lint": "eslint --quiet \"**/*.{js,mjs}\"",
+    "lint": "eslint --quiet \"**/*\"",
     "precommit": "lint-staged",
     "release:prepare-changelog": "node ./scripts/preparechangelog.mjs",
     "release:prepare-packages": "node ./scripts/preparepackages.mjs",
@@ -51,5 +51,8 @@
     "**/*.{js,mjs}": [
       "eslint --quiet"
     ]
+  },
+  "dependencies": {
+    "eslint-plugin-yml": "^1.18.0"
   }
 }

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/validate-changelog-entry.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/validate-changelog-entry.js
@@ -37,7 +37,6 @@ const NICK_NAME_PATTERN = /^(@?)[a-z0-9-_]+$/i;
 module.exports = {
 	meta: {
 		type: 'problem',
-		fixable: 'whitespace',
 		docs: {
 			description: 'Validate changelog entries.',
 			category: 'CKEditor5',

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/validate-changelog-entry.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/validate-changelog-entry.js
@@ -37,6 +37,7 @@ const NICK_NAME_PATTERN = /^(@?)[a-z0-9-_]+$/i;
 module.exports = {
 	meta: {
 		type: 'problem',
+		fixable: 'whitespace',
 		docs: {
 			description: 'Validate changelog entries.',
 			category: 'CKEditor5',
@@ -121,6 +122,26 @@ module.exports = {
 								end: {
 									line: lineOffset + end.line,
 									column: end.col
+								}
+							}
+						} );
+					} );
+
+				doc.errors
+					.filter( ( { code } ) => code === 'TAB_AS_INDENT' )
+					.forEach( ( { linePos } ) => {
+						const lineOffset = node.position.start.line;
+
+						context.report( {
+							message: 'Indentation should use spaces instead of tabs.',
+							loc: {
+								start: {
+									line: lineOffset + linePos[ 0 ].line,
+									column: linePos[ 0 ].col
+								},
+								end: {
+									line: lineOffset + linePos[ 1 ].line,
+									column: linePos[ 1 ].col
 								}
 							}
 						} );

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/validate-changelog-entry.mjs
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/validate-changelog-entry.mjs
@@ -523,6 +523,25 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/validate-changelog-entry', rule, 
 			errors: [
 				'Invalid \'communityCredits\' value: \'%^&*\'.'
 			]
+		},
+
+		// Invalid intent using tabs.
+		{
+			code: dedent`
+			---
+			type: feature
+			scope:
+				- test
+				- test2
+			---
+
+			Change summary.
+			`,
+			options: [ { repositoryType: 'mono', allowedScopes: [ 'test', 'test2' ] } ],
+			errors: [
+				'Indentation should use spaces instead of tabs.',
+				'Indentation should use spaces instead of tabs.'
+			]
 		}
 	]
 } );

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/validate-changelog-entry.mjs
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/validate-changelog-entry.mjs
@@ -525,7 +525,7 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/validate-changelog-entry', rule, 
 			]
 		},
 
-		// Invalid intent using tabs.
+		// Invalid indent using tabs.
 		{
 			code: dedent`
 			---


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Added validation to ensure that changeset files are indented using spaces instead of tabs.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes https://github.com/ckeditor/ckeditor5/issues/19026

---

### 💡 Additional information

I've additionaly updated the `lint` command to lint all files, so that changeset files are also included.

---

The rule now `validate-changelog-entry` now reports tabs as errors.

<img width="408" height="306" alt="image" src="https://github.com/user-attachments/assets/22f72837-1c17-4c2f-879d-6f0fd3104252" />

```
pnpm run lint

> @ckeditor/ckeditor5-linters-config@12.1.1 lint /home/zanju/repositories/ckeditor5-linters-config
> eslint --quiet "**/*"


/home/zanju/repositories/ckeditor5-linters-config/.changelog/20250929114234_ck_19026.md
  40:1  error  Indentation should use spaces instead of tabs  ckeditor5-rules/validate-changelog-entry
  44:1  error  Indentation should use spaces instead of tabs  ckeditor5-rules/validate-changelog-entry
  45:1  error  Indentation should use spaces instead of tabs  ckeditor5-rules/validate-changelog-entry
  46:1  error  Indentation should use spaces instead of tabs  ckeditor5-rules/validate-changelog-entry
  47:1  error  Indentation should use spaces instead of tabs  ckeditor5-rules/validate-changelog-entry
  48:1  error  Indentation should use spaces instead of tabs  ckeditor5-rules/validate-changelog-entry
  49:1  error  Indentation should use spaces instead of tabs  ckeditor5-rules/validate-changelog-entry
  50:1  error  Indentation should use spaces instead of tabs  ckeditor5-rules/validate-changelog-entry

✖ 8 problems (8 errors, 0 warnings)

```


---

I've considered adding fixer, but in the end I did not, as it is ambiguous what amount of spaces should replace the tabs.
