### PR TITLE
Update dependencies.

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,12 @@ minimumReleaseAgeExclude:
   - '@ckeditor/*'
   - '@cksource/*'
   - '*ckeditor5*'
+  - 'diff' # Remove after 2026-07-13.
+  - 'serialize-javascript' # Remove after 2026-07-13.
+
+overrides:
+  'diff@^7': '^8.0.3'
+  'serialize-javascript@^6': '^7.0.5'
 
 shellEmulator: true
 shamefullyHoist: true


### PR DESCRIPTION
### 🚀 Summary

* Updated `diff` to `^8.0.3` and `serialize-javascript` to `^7.0.5` via `pnpm-workspace.yaml` overrides.

---

### 📌 Related issues

* See: https://github.com/ckeditor/ckeditor5-internal/issues/4391

---

### 💡 Additional information

This is an internal-only change — no changelog entry needed.