### PR TITLE
Added a no-enum rule.

### DIFF
--- a/.changelog/20260413132040_master.md
+++ b/.changelog/20260413132040_master.md
@@ -1,0 +1,7 @@
+---
+type: Major breaking change
+scope:
+  - eslint-config-ckeditor5
+---
+
+Enabled the new `ckeditor5-rules/no-enum` rule. Enums are now disallowed by default.

--- a/.changelog/20260413132448_ci_4343.md
+++ b/.changelog/20260413132448_ci_4343.md
@@ -1,0 +1,7 @@
+---
+type: Feature
+scope:
+  - eslint-plugin-ckeditor5-rules
+---
+
+Enabled a new `ckeditor5-rules/no-enum` rule. It disallows usage of typescript Enums.

--- a/.changelog/20260413132448_ci_4343.md
+++ b/.changelog/20260413132448_ci_4343.md
@@ -4,4 +4,4 @@ scope:
   - eslint-plugin-ckeditor5-rules
 ---
 
-Enabled a new `ckeditor5-rules/no-enum` rule. It disallows usage of typescript Enums.
+Added a new `ckeditor5-rules/no-enum` rule. It disallows usage of typescript Enums.

--- a/packages/eslint-config-ckeditor5/eslint.config.mjs
+++ b/packages/eslint-config-ckeditor5/eslint.config.mjs
@@ -415,6 +415,8 @@ const rulesSourceCode = [
 
 			'ckeditor5-rules/no-scoped-imports-within-package': 'error',
 
+			'ckeditor5-rules/no-enum': 'error',
+
 			'ckeditor5-rules/use-require-for-debug-mode-imports': 'error',
 
 			'ckeditor5-rules/no-istanbul-in-debug-code': 'error',

--- a/packages/eslint-plugin-ckeditor5-rules/lib/index.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/index.js
@@ -8,6 +8,7 @@
 module.exports = {
 	rules: {
 		'no-relative-imports': require( './rules/no-relative-imports' ),
+		'no-enum': require( './rules/no-enum' ),
 		'ckeditor-error-message': require( './rules/ckeditor-error-message' ),
 		'ckeditor-plugin-flags': require( './rules/ckeditor-plugin-flags.js' ),
 		'enforce-node-protocol': require( './rules/enforce-node-protocol' ),

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-enum.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-enum.js
@@ -1,0 +1,30 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+module.exports = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Disallow TypeScript enum declarations.',
+			category: 'CKEditor5'
+		},
+		schema: [],
+		messages: {
+			noEnum: 'The TypeScript "enum" keyword is disallowed. Use a const object or union types instead.'
+		}
+	},
+	create( context ) {
+		return {
+			TSEnumDeclaration( node ) {
+				context.report( {
+					node,
+					messageId: 'noEnum'
+				} );
+			}
+		};
+	}
+};

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-enum.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-enum.js
@@ -1,0 +1,76 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const RuleTester = require( 'eslint' ).RuleTester;
+const parser = require( '@typescript-eslint/parser' );
+
+const errorMessage = 'The TypeScript "enum" keyword is disallowed. Use a const object or union types instead.';
+
+const ruleTester = new RuleTester( {
+	languageOptions: {
+		parser
+	}
+} );
+
+ruleTester.run( 'no-enum', require( '../../lib/rules/no-enum' ), {
+	valid: [
+		{
+			code: `
+				const Colors = {
+					red: 'red',
+					blue: 'blue'
+				} as const;
+
+				type Color = typeof Colors[ keyof typeof Colors ];
+			`
+		},
+		{
+			code: 'type State = \'ready\' | \'busy\';'
+		}
+	],
+	invalid: [
+		{
+			code: `
+				enum Color {
+					Red = 'red',
+					Blue = 'blue'
+				}
+			`,
+			errors: [
+				{
+					message: errorMessage
+				}
+			]
+		},
+		{
+			code: `
+				const enum Permission {
+					Read = 1,
+					Write = 2
+				}
+			`,
+			errors: [
+				{
+					message: errorMessage
+				}
+			]
+		},
+		{
+			code: `
+				declare enum Status {
+					Ready,
+					Busy
+				}
+			`,
+			errors: [
+				{
+					message: errorMessage
+				}
+			]
+		}
+	]
+} );

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-enum.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-enum.js
@@ -71,6 +71,19 @@ ruleTester.run( 'no-enum', require( '../../lib/rules/no-enum' ), {
 					message: errorMessage
 				}
 			]
+		},
+		{
+			code: `
+				enum Status {
+					Ready,
+					Busy
+				}
+			`,
+			errors: [
+				{
+					message: errorMessage
+				}
+			]
 		}
 	]
 } );


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Added a new `no-enum` rule. Enabled it in the default config.

---

### 💡 Additional information

Testing:
- Link the `ckeditor5-linters-config` repository in `ckeditor5`.
- Add an `enum` in `ckeditor5`. There should be an error.
