### PR TITLE
Added 2 new rules: no-literal-dollar-root and require-explicit-data-context

### DIFF
--- a/.changelog/20260428183923_ck_20096.md
+++ b/.changelog/20260428183923_ck_20096.md
@@ -8,4 +8,4 @@ see:
   - https://github.com/ckeditor/ckeditor5/issues/20026
 ---
 
-Added two ESLint rules that flag implicit `$root` schema-context usage: `ckeditor5-rules/no-literal-dollar-root` (disallows hardcoded `'$root'` literals outside engine/core) and `ckeditor5-rules/require-explicit-data-context` (requires an explicit context argument on `data.parse()` / `data.toModel()` calls).
+Added two ESLint rules that flag implicit `$root` schema-context usage: `ckeditor5-rules/no-literal-dollar-root` (disallows hardcoded `'$root'` literals outside engine/core) and `ckeditor5-rules/require-explicit-data-context` (requires an explicit context argument on `data.parse()`, `data.toModel()`, `model.document.createRoot()` and `writer.addRoot()` calls).

--- a/.changelog/20260428183923_ck_20096.md
+++ b/.changelog/20260428183923_ck_20096.md
@@ -1,0 +1,11 @@
+---
+type: Feature
+scope:
+  - eslint-plugin-ckeditor5-rules
+closes:
+  - https://github.com/ckeditor/ckeditor5/issues/20096
+see:
+  - https://github.com/ckeditor/ckeditor5/issues/20026
+---
+
+Added two ESLint rules that flag implicit `$root` schema-context usage: `ckeditor5-rules/no-literal-dollar-root` (disallows hardcoded `'$root'` literals outside engine/core) and `ckeditor5-rules/require-explicit-data-context` (requires an explicit context argument on `data.parse()` / `data.toModel()` calls).

--- a/.changelog/20260428183923_ck_20096.md
+++ b/.changelog/20260428183923_ck_20096.md
@@ -8,4 +8,4 @@ see:
   - https://github.com/ckeditor/ckeditor5/issues/20026
 ---
 
-Added two ESLint rules that flag implicit `$root` schema-context usage: `ckeditor5-rules/no-literal-dollar-root` (disallows hardcoded `'$root'` literals outside engine/core) and `ckeditor5-rules/require-explicit-data-context` (requires an explicit context argument on `data.parse()`, `data.toModel()`, `model.document.createRoot()` and `writer.addRoot()` calls).
+Added two ESLint rules that flag implicit `$root` schema-context usage: `ckeditor5-rules/no-literal-dollar-root` (disallows hardcoded `'$root'` literals outside engine/core) and `ckeditor5-rules/require-explicit-data-context` (requires an explicit context argument on `data.parse()`, `data.toModel()`, `model.document.createRoot()`, `writer.addRoot()`, and `upcastDispatcher.convert()` calls).

--- a/packages/eslint-plugin-ckeditor5-rules/lib/index.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/index.js
@@ -19,6 +19,8 @@ module.exports = {
 		'use-require-for-debug-mode-imports': require( './rules/use-require-for-debug-mode-imports' ),
 		'non-public-members-as-internal': require( './rules/non-public-members-as-internal' ),
 		'no-istanbul-in-debug-code': require( './rules/no-istanbul-in-debug-code' ),
+		'no-literal-dollar-root': require( './rules/no-literal-dollar-root' ),
+		'require-explicit-data-context': require( './rules/require-explicit-data-context' ),
 		'allow-declare-module-only-in-augmentation-file': require( './rules/allow-declare-module-only-in-augmentation-file' ),
 		'allow-imports-only-from-main-package-entry-point': require( './rules/allow-imports-only-from-main-package-entry-point.js' ),
 		'allow-svg-imports-only-in-icons-package': require( './rules/allow-svg-imports-only-in-icons-package.js' ),

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-literal-dollar-root.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-literal-dollar-root.js
@@ -1,0 +1,329 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+module.exports = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Disallow hardcoding the "$root" string literal as a schema context outside engine/core.',
+			category: 'CKEditor5'
+		},
+		fixable: 'code',
+		schema: [
+			{
+				type: 'object',
+				properties: {
+					allowedPackages: {
+						type: 'array',
+						items: { type: 'string' }
+					},
+					allowedCalls: {
+						type: 'array',
+						items: { type: 'string' }
+					}
+				},
+				additionalProperties: false
+			}
+		],
+		messages: {
+			literalDollarRoot:
+				'Avoid hardcoding "$root" as a schema context — it is silently wrong when "config.root.modelElement" is customised. ' +
+				'Use the configured root name (e.g. via "rootConfig.modelElement"), or use "rootElement" via ".is( \'rootElement\' )".',
+			isElementDollarRoot:
+				'Use ".is( \'rootElement\' )" instead of ".is( \'element\', \'$root\' )" — name-agnostic across configured roots.',
+			nameEqualsDollarRoot:
+				'Use "{{ replacement }}" instead of comparing ".name" against "$root" — name-agnostic across configured roots.'
+		}
+	},
+
+	create( context ) {
+		const options = context.options[ 0 ] || {};
+		const allowedPackages = options.allowedPackages || [];
+		const allowedCalls = options.allowedCalls || [];
+
+		const filename = context.filename || '';
+
+		if ( allowedPackages.some( pkg => filename.includes( pkg ) ) ) {
+			return {};
+		}
+
+		const sourceCode = context.sourceCode;
+
+		return {
+			CallExpression( node ) {
+				if ( !isIsElementDollarRootCall( node ) ) {
+					return;
+				}
+
+				context.report( {
+					node,
+					messageId: 'isElementDollarRoot',
+					fix: fixer => {
+						const objectText = sourceCode.getText( node.callee.object );
+						const accessor = node.callee.optional ? '?.' : '.';
+
+						return fixer.replaceText( node, `${ objectText }${ accessor }is( 'rootElement' )` );
+					}
+				} );
+			},
+
+			BinaryExpression( node ) {
+				const match = matchNameEqualsDollarRoot( node );
+
+				if ( !match ) {
+					return;
+				}
+
+				const objectText = sourceCode.getText( match.object );
+				const replacement = match.negated ? `!${ objectText }.is( 'rootElement' )` : `${ objectText }.is( 'rootElement' )`;
+
+				context.report( {
+					node,
+					messageId: 'nameEqualsDollarRoot',
+					data: { replacement },
+					fix: fixer => fixer.replaceText( node, replacement )
+				} );
+			},
+
+			Literal( node ) {
+				if ( node.value !== '$root' ) {
+					return;
+				}
+
+				if ( isInsideAllowedCall( node, allowedCalls ) ) {
+					return;
+				}
+
+				if ( isAllowedSchemaExtendForAttributes( node ) ) {
+					return;
+				}
+
+				if ( isAllowedViewEventContext( node ) ) {
+					return;
+				}
+
+				if ( isReportedByCallExpressionCheck( node ) ) {
+					return;
+				}
+
+				if ( isReportedByBinaryExpressionCheck( node ) ) {
+					return;
+				}
+
+				context.report( {
+					node,
+					messageId: 'literalDollarRoot'
+				} );
+			}
+		};
+	}
+};
+
+/**
+ * Matches `<obj>.is( 'element', '$root' )` calls.
+ */
+function isIsElementDollarRootCall( node ) {
+	const callee = node.callee;
+
+	if ( !callee || callee.type !== 'MemberExpression' ) {
+		return false;
+	}
+
+	if ( callee.computed || callee.property.type !== 'Identifier' || callee.property.name !== 'is' ) {
+		return false;
+	}
+
+	if ( node.arguments.length !== 2 ) {
+		return false;
+	}
+
+	const [ first, second ] = node.arguments;
+
+	return isStringLiteral( first, 'element' ) && isStringLiteral( second, '$root' );
+}
+
+/**
+ * Matches `<obj>.name === '$root'` and `<obj>.name !== '$root'` (and the flipped order).
+ */
+function matchNameEqualsDollarRoot( node ) {
+	if ( node.operator !== '===' && node.operator !== '!==' ) {
+		return null;
+	}
+
+	const left = node.left;
+	const right = node.right;
+
+	const fromLeft = matchNameAccessor( left ) && isStringLiteral( right, '$root' ) ? matchNameAccessor( left ) : null;
+	const fromRight = matchNameAccessor( right ) && isStringLiteral( left, '$root' ) ? matchNameAccessor( right ) : null;
+
+	const accessor = fromLeft || fromRight;
+
+	if ( !accessor ) {
+		return null;
+	}
+
+	return {
+		object: accessor.object,
+		negated: node.operator === '!=='
+	};
+}
+
+/**
+ * Matches a `<obj>.name` member expression. Returns the inner object on match.
+ */
+function matchNameAccessor( node ) {
+	if ( !node || node.type !== 'MemberExpression' ) {
+		return null;
+	}
+
+	if ( node.computed || node.property.type !== 'Identifier' || node.property.name !== 'name' ) {
+		return null;
+	}
+
+	return { object: node.object };
+}
+
+function isStringLiteral( node, value ) {
+	return node && node.type === 'Literal' && node.value === value;
+}
+
+/**
+ * Whether the literal sits as an argument to a call whose method name is in `allowedCalls`.
+ */
+function isInsideAllowedCall( literalNode, allowedCalls ) {
+	if ( !allowedCalls.length ) {
+		return false;
+	}
+
+	const parent = literalNode.parent;
+
+	if ( !parent || parent.type !== 'CallExpression' ) {
+		return false;
+	}
+
+	if ( !parent.arguments.includes( literalNode ) ) {
+		return false;
+	}
+
+	const callee = parent.callee;
+
+	if ( !callee || callee.type !== 'MemberExpression' || callee.computed ) {
+		return false;
+	}
+
+	if ( callee.property.type !== 'Identifier' ) {
+		return false;
+	}
+
+	return allowedCalls.includes( callee.property.name );
+}
+
+/**
+ * Whether the literal is the first arg of `*.extend( '$root', { allowAttributes: … } )` — adding an attribute to the
+ * default root model element is the documented escape hatch for features that only contribute attributes (not children
+ * or any other schema rules), so it stays allowed even outside engine/core. Any extra key on the schema-rules object
+ * disqualifies the call site and the literal is reported normally.
+ */
+function isAllowedSchemaExtendForAttributes( literalNode ) {
+	const parent = literalNode.parent;
+
+	if ( !parent || parent.type !== 'CallExpression' || parent.arguments[ 0 ] !== literalNode ) {
+		return false;
+	}
+
+	const callee = parent.callee;
+
+	if ( !callee || callee.type !== 'MemberExpression' || callee.computed ) {
+		return false;
+	}
+
+	if ( callee.property.type !== 'Identifier' || callee.property.name !== 'extend' ) {
+		return false;
+	}
+
+	const secondArg = parent.arguments[ 1 ];
+
+	if ( !secondArg || secondArg.type !== 'ObjectExpression' || secondArg.properties.length !== 1 ) {
+		return false;
+	}
+
+	const prop = secondArg.properties[ 0 ];
+
+	if ( prop.type !== 'Property' || prop.computed ) {
+		return false;
+	}
+
+	if ( prop.key.type === 'Identifier' ) {
+		return prop.key.name === 'allowAttributes';
+	}
+
+	if ( prop.key.type === 'Literal' ) {
+		return prop.key.value === 'allowAttributes';
+	}
+
+	return false;
+}
+
+/**
+ * Whether the literal is the value of a `context` property — covers view-event listener options like
+ * `listenTo( …, { context: '$root' } )` and `{ context: [ isWidget, '$root' ] }`. In that position `'$root'`
+ * is a view-tree bubbling target, not the schema element name.
+ */
+function isAllowedViewEventContext( literalNode ) {
+	const direct = literalNode.parent;
+	let propertyNode = null;
+
+	if ( direct && direct.type === 'Property' && direct.value === literalNode ) {
+		propertyNode = direct;
+	} else if ( direct && direct.type === 'ArrayExpression' ) {
+		const arrayParent = direct.parent;
+
+		if ( arrayParent && arrayParent.type === 'Property' && arrayParent.value === direct ) {
+			propertyNode = arrayParent;
+		}
+	}
+
+	if ( !propertyNode || propertyNode.computed ) {
+		return false;
+	}
+
+	if ( propertyNode.key.type === 'Identifier' ) {
+		return propertyNode.key.name === 'context';
+	}
+
+	if ( propertyNode.key.type === 'Literal' ) {
+		return propertyNode.key.value === 'context';
+	}
+
+	return false;
+}
+
+/**
+ * Whether the literal is the second arg of a `.is( 'element', '$root' )` call (already reported by the CallExpression handler).
+ */
+function isReportedByCallExpressionCheck( literalNode ) {
+	const parent = literalNode.parent;
+
+	if ( !parent || parent.type !== 'CallExpression' ) {
+		return false;
+	}
+
+	return isIsElementDollarRootCall( parent ) && parent.arguments[ 1 ] === literalNode;
+}
+
+/**
+ * Whether the literal is the `'$root'` operand of a `<obj>.name === '$root'` comparison (already reported by the BinaryExpression handler).
+ */
+function isReportedByBinaryExpressionCheck( literalNode ) {
+	const parent = literalNode.parent;
+
+	if ( !parent || parent.type !== 'BinaryExpression' ) {
+		return false;
+	}
+
+	return matchNameEqualsDollarRoot( parent ) !== null;
+}

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-literal-dollar-root.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-literal-dollar-root.js
@@ -319,63 +319,95 @@ const VIEW_LISTENER_METHODS = new Set( [ 'listenTo', 'on', 'once', 'off' ] );
  * so an unrelated call like `someApi( { context: '$root' } )` still gets flagged.
  */
 function isAllowedViewEventContext( literalNode ) {
-	const direct = literalNode.parent;
-	let propertyNode = null;
+	const propertyNode = getOwningContextProperty( literalNode );
 
-	if ( direct && direct.type === 'Property' && direct.value === literalNode ) {
-		propertyNode = direct;
-	} else if ( direct && direct.type === 'ArrayExpression' ) {
-		const arrayParent = direct.parent;
+	if ( !isPropertyNamed( propertyNode, 'context' ) ) {
+		return false;
+	}
 
-		if ( arrayParent && arrayParent.type === 'Property' && arrayParent.value === direct ) {
-			propertyNode = arrayParent;
+	const callExpression = getEnclosingObjectArgumentCall( propertyNode );
+
+	return hasAllowedListenerMethod( callExpression );
+}
+
+/**
+ * Returns the `Property` AST node whose value is the literal — directly (`{ context: literal }`) or via an inline
+ * array (`{ context: [ ..., literal ] }`). Returns null when the literal is not in such a position.
+ */
+function getOwningContextProperty( literalNode ) {
+	const parent = literalNode.parent;
+
+	if ( parent && parent.type === 'Property' && parent.value === literalNode ) {
+		return parent;
+	}
+
+	if ( parent && parent.type === 'ArrayExpression' ) {
+		const propertyNode = parent.parent;
+
+		if ( propertyNode && propertyNode.type === 'Property' && propertyNode.value === parent ) {
+			return propertyNode;
 		}
 	}
 
+	return null;
+}
+
+/**
+ * Whether the property's key (identifier or string literal, never computed) equals `expectedName`.
+ */
+function isPropertyNamed( propertyNode, expectedName ) {
 	if ( !propertyNode || propertyNode.computed ) {
 		return false;
 	}
 
 	if ( propertyNode.key.type === 'Identifier' ) {
-		if ( propertyNode.key.name !== 'context' ) {
-			return false;
-		}
-	} else if ( propertyNode.key.type === 'Literal' ) {
-		if ( propertyNode.key.value !== 'context' ) {
-			return false;
-		}
-	} else {
-		return false;
+		return propertyNode.key.name === expectedName;
 	}
 
-	// The enclosing object literal must be an argument to a view-listener method call (`listenTo`, `on`, `once`, `off`).
-	const objectLiteral = propertyNode.parent;
+	if ( propertyNode.key.type === 'Literal' ) {
+		return propertyNode.key.value === expectedName;
+	}
+
+	return false;
+}
+
+/**
+ * Returns the call expression that receives the property's enclosing object literal as one of its arguments.
+ * Returns null when the property is not nested in a `<call>( …, { … }, … )` shape.
+ */
+function getEnclosingObjectArgumentCall( propertyNode ) {
+	const objectLiteral = propertyNode && propertyNode.parent;
 
 	if ( !objectLiteral || objectLiteral.type !== 'ObjectExpression' ) {
-		return false;
+		return null;
 	}
 
 	const callExpression = objectLiteral.parent;
 
 	if ( !callExpression || callExpression.type !== 'CallExpression' ) {
-		return false;
+		return null;
 	}
 
 	if ( !callExpression.arguments.includes( objectLiteral ) ) {
-		return false;
+		return null;
 	}
 
-	const callee = callExpression.callee;
+	return callExpression;
+}
 
-	if ( !callee || callee.type !== 'MemberExpression' || callee.computed ) {
-		return false;
-	}
+/**
+ * Whether the call's callee is a non-computed member expression invoking one of the allowed view-listener methods.
+ */
+function hasAllowedListenerMethod( callExpression ) {
+	const callee = callExpression && callExpression.callee;
 
-	if ( callee.property.type !== 'Identifier' ) {
-		return false;
-	}
-
-	return VIEW_LISTENER_METHODS.has( callee.property.name );
+	return Boolean(
+		callee &&
+		callee.type === 'MemberExpression' &&
+		!callee.computed &&
+		callee.property.type === 'Identifier' &&
+		VIEW_LISTENER_METHODS.has( callee.property.name )
+	);
 }
 
 /**

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-literal-dollar-root.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-literal-dollar-root.js
@@ -59,16 +59,24 @@ module.exports = {
 					return;
 				}
 
-				context.report( {
+				const report = {
 					node,
-					messageId: 'isElementDollarRoot',
-					fix: fixer => {
+					messageId: 'isElementDollarRoot'
+				};
+
+				// AST node ranges exclude grouping parens, so splicing `getText( object )` for a complex receiver
+				// (e.g. `( a || b ).is( 'element', '$root' )`) would drop the parens and silently change operator
+				// precedence. Skip the autofix in those cases — the developer rewrites by hand.
+				if ( isSafeReceiver( node.callee.object ) ) {
+					report.fix = fixer => {
 						const objectText = sourceCode.getText( node.callee.object );
 						const accessor = node.callee.optional ? '?.' : '.';
 
 						return fixer.replaceText( node, `${ objectText }${ accessor }is( 'rootElement' )` );
-					}
-				} );
+					};
+				}
+
+				context.report( report );
 			},
 
 			BinaryExpression( node ) {
@@ -79,14 +87,25 @@ module.exports = {
 				}
 
 				const objectText = sourceCode.getText( match.object );
-				const replacement = match.negated ? `!${ objectText }.is( 'rootElement' )` : `${ objectText }.is( 'rootElement' )`;
+				const safeReceiver = isSafeReceiver( match.object );
+				// For unsafe receivers (e.g. `( a || b ).name === '$root'`) wrap the suggestion in parens so the
+				// hint text in the message is itself valid; the actual autofix is skipped — see CallExpression note.
+				const receiverText = safeReceiver ? objectText : `( ${ objectText } )`;
+				const replacement = match.negated ?
+					`!${ receiverText }.is( 'rootElement' )` :
+					`${ receiverText }.is( 'rootElement' )`;
 
-				context.report( {
+				const report = {
 					node,
 					messageId: 'nameEqualsDollarRoot',
-					data: { replacement },
-					fix: fixer => fixer.replaceText( node, replacement )
-				} );
+					data: { replacement }
+				};
+
+				if ( safeReceiver ) {
+					report.fix = fixer => fixer.replaceText( node, replacement );
+				}
+
+				context.report( report );
 			},
 
 			Literal( node ) {
@@ -189,6 +208,27 @@ function matchNameAccessor( node ) {
 
 function isStringLiteral( node, value ) {
 	return node && node.type === 'Literal' && node.value === value;
+}
+
+/**
+ * Whether splicing `sourceCode.getText( node )` directly into `${ text }.is( 'rootElement' )` is safe — i.e. the
+ * receiver does not need parens to keep its semantics. Only nodes that bind tighter than member access qualify.
+ */
+function isSafeReceiver( node ) {
+	if ( !node ) {
+		return false;
+	}
+
+	switch ( node.type ) {
+		case 'Identifier':
+		case 'MemberExpression':
+		case 'CallExpression':
+		case 'ChainExpression':
+		case 'ThisExpression':
+			return true;
+		default:
+			return false;
+	}
 }
 
 /**

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-literal-dollar-root.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-literal-dollar-root.js
@@ -308,10 +308,15 @@ function isAllowedSchemaExtendForAttributes( literalNode ) {
 	return false;
 }
 
+const VIEW_LISTENER_METHODS = new Set( [ 'listenTo', 'on', 'once', 'off' ] );
+
 /**
- * Whether the literal is the value of a `context` property — covers view-event listener options like
- * `listenTo( …, { context: '$root' } )` and `{ context: [ isWidget, '$root' ] }`. In that position `'$root'`
- * is a view-tree bubbling target, not the schema element name.
+ * Whether the literal is the value of a `context` property on an options object passed to a view-event listener
+ * call — `listenTo( …, { context: '$root' } )`, `view.on( 'event', cb, { context: [ isWidget, '$root' ] } )`, etc.
+ * In that position `'$root'` is a view-tree bubbling target, not a schema element name.
+ *
+ * The check is intentionally narrow: only object literals passed to one of `listenTo`, `on`, `once`, `off` qualify,
+ * so an unrelated call like `someApi( { context: '$root' } )` still gets flagged.
  */
 function isAllowedViewEventContext( literalNode ) {
 	const direct = literalNode.parent;
@@ -332,14 +337,45 @@ function isAllowedViewEventContext( literalNode ) {
 	}
 
 	if ( propertyNode.key.type === 'Identifier' ) {
-		return propertyNode.key.name === 'context';
+		if ( propertyNode.key.name !== 'context' ) {
+			return false;
+		}
+	} else if ( propertyNode.key.type === 'Literal' ) {
+		if ( propertyNode.key.value !== 'context' ) {
+			return false;
+		}
+	} else {
+		return false;
 	}
 
-	if ( propertyNode.key.type === 'Literal' ) {
-		return propertyNode.key.value === 'context';
+	// The enclosing object literal must be an argument to a view-listener method call (`listenTo`, `on`, `once`, `off`).
+	const objectLiteral = propertyNode.parent;
+
+	if ( !objectLiteral || objectLiteral.type !== 'ObjectExpression' ) {
+		return false;
 	}
 
-	return false;
+	const callExpression = objectLiteral.parent;
+
+	if ( !callExpression || callExpression.type !== 'CallExpression' ) {
+		return false;
+	}
+
+	if ( !callExpression.arguments.includes( objectLiteral ) ) {
+		return false;
+	}
+
+	const callee = callExpression.callee;
+
+	if ( !callee || callee.type !== 'MemberExpression' || callee.computed ) {
+		return false;
+	}
+
+	if ( callee.property.type !== 'Identifier' ) {
+		return false;
+	}
+
+	return VIEW_LISTENER_METHODS.has( callee.property.name );
 }
 
 /**

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/require-explicit-data-context.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/require-explicit-data-context.js
@@ -1,0 +1,91 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const DEFAULT_METHODS = [ 'parse', 'toModel' ];
+
+module.exports = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Require an explicit schema context when calling "data.parse()" / "data.toModel()".',
+			category: 'CKEditor5'
+		},
+		schema: [
+			{
+				type: 'object',
+				properties: {
+					methods: {
+						type: 'array',
+						items: { type: 'string' }
+					}
+				},
+				additionalProperties: false
+			}
+		],
+		messages: {
+			missingContext:
+				'Pass an explicit schema context to "data.{{ method }}()". Without it the API falls back to "$root", ' +
+				'which is silently wrong when "config.root.modelElement" is customised. ' +
+				'If you have verified that the default is acceptable here, opt out with an ' +
+				'"// eslint-disable-next-line" comment that explains why.'
+		}
+	},
+
+	create( context ) {
+		const options = context.options[ 0 ] || {};
+		const methods = options.methods || DEFAULT_METHODS;
+
+		return {
+			CallExpression( node ) {
+				if ( node.arguments.length !== 1 ) {
+					return;
+				}
+
+				const callee = node.callee;
+
+				if ( !callee || callee.type !== 'MemberExpression' || callee.computed ) {
+					return;
+				}
+
+				if ( callee.property.type !== 'Identifier' || !methods.includes( callee.property.name ) ) {
+					return;
+				}
+
+				if ( !isDataReceiver( callee.object ) ) {
+					return;
+				}
+
+				context.report( {
+					node,
+					messageId: 'missingContext',
+					data: { method: callee.property.name }
+				} );
+			}
+		};
+	}
+};
+
+/**
+ * Whether the receiver looks like a `data` reference:
+ * - a bare `Identifier` named `data` (covers `const { data } = editor; data.parse( … )`),
+ * - or a `MemberExpression` whose final accessed property is `data` (covers `editor.data`, `this.data`, `foo.bar.data`, etc.).
+ */
+function isDataReceiver( node ) {
+	if ( !node ) {
+		return false;
+	}
+
+	if ( node.type === 'Identifier' && node.name === 'data' ) {
+		return true;
+	}
+
+	if ( node.type === 'MemberExpression' && !node.computed && node.property.type === 'Identifier' && node.property.name === 'data' ) {
+		return true;
+	}
+
+	return false;
+}

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/require-explicit-data-context.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/require-explicit-data-context.js
@@ -16,19 +16,19 @@
 const RULES = [
 	{
 		method: 'parse',
-		matchReceiver: matchDataReceiver,
+		matchReceiver: node => matchIdentifierReceiver( node, 'data' ),
 		isMissingContext: args => args.length === 1,
 		label: 'data.parse()'
 	},
 	{
 		method: 'toModel',
-		matchReceiver: matchDataReceiver,
+		matchReceiver: node => matchIdentifierReceiver( node, 'data' ),
 		isMissingContext: args => args.length === 1,
 		label: 'data.toModel()'
 	},
 	{
 		method: 'createRoot',
-		matchReceiver: matchDocumentReceiver,
+		matchReceiver: node => matchIdentifierReceiver( node, 'document' ),
 		isMissingContext: args => args.length === 0,
 		label: 'document.createRoot()'
 	},
@@ -41,7 +41,7 @@ const RULES = [
 	{
 		// `upcastDispatcher.convert( viewElementOrFragment, writer, context = [ '$root' ] )` — third arg is the schema context.
 		method: 'convert',
-		matchReceiver: matchUpcastDispatcherReceiver,
+		matchReceiver: node => matchIdentifierReceiver( node, 'upcastDispatcher' ),
 		isMissingContext: args => args.length === 2,
 		label: 'upcastDispatcher.convert()'
 	}
@@ -103,69 +103,31 @@ module.exports = {
 };
 
 /**
- * Matches `data`, `editor.data`, `this.data`, `foo.bar.data`, etc. — i.e. any reference whose final accessed property
- * is `data`, plus a bare `data` identifier (covers destructured `const { data } = editor` patterns).
+ * Matches a receiver whose final accessed property name (or bare identifier name) is `expectedName`. Covers both
+ * member-access chains (`editor.data`, `this.model.document`, `editor.data.upcastDispatcher`) and destructured /
+ * aliased identifiers (`const { data } = editor; data.parse(...)`).
  */
-function matchDataReceiver( node ) {
+function matchIdentifierReceiver( node, expectedName ) {
 	if ( !node ) {
 		return false;
 	}
 
-	if ( node.type === 'Identifier' && node.name === 'data' ) {
+	if ( node.type === 'Identifier' && node.name === expectedName ) {
 		return true;
 	}
 
 	return node.type === 'MemberExpression' &&
 		!node.computed &&
 		node.property.type === 'Identifier' &&
-		node.property.name === 'data';
-}
-
-/**
- * Matches a receiver whose final accessed property is `document` (e.g. `editor.model.document`, `this.model.document`).
- * The model document is the only `document` in the engine that exposes `createRoot()`, so this filter is enough to
- * exclude unrelated `*.createRoot()` calls without false positives.
- */
-function matchDocumentReceiver( node ) {
-	if ( !node ) {
-		return false;
-	}
-
-	if ( node.type === 'Identifier' && node.name === 'document' ) {
-		return true;
-	}
-
-	return node.type === 'MemberExpression' &&
-		!node.computed &&
-		node.property.type === 'Identifier' &&
-		node.property.name === 'document';
+		node.property.name === expectedName;
 }
 
 /**
  * Matches a receiver named `writer` (i.e. a `ModelWriter` from `model.change( writer => … )` or `model.enqueueChange`).
- * Crucially this excludes `MultiRootEditor#addRoot( rootName, options? )` — that public API has a different
- * second-arg shape (options object) and resolves the model element name internally, so it must not be flagged.
+ * Stricter than `matchIdentifierReceiver` — only a bare `writer` identifier qualifies, never `*.writer` chains.
+ * This excludes `MultiRootEditor#addRoot( rootName, options? )`, whose receiver is `editor` / `this` and which has
+ * a different signature (options object as the second arg, with the model element name resolved internally).
  */
 function matchWriterReceiver( node ) {
 	return Boolean( node ) && node.type === 'Identifier' && node.name === 'writer';
-}
-
-/**
- * Matches a receiver whose final accessed property is `upcastDispatcher` (e.g. `editor.data.upcastDispatcher`).
- * The upcast dispatcher is the only API in the engine that exposes a `convert()` method with a defaulted schema
- * context, so this filter excludes unrelated `*.convert()` calls without false positives.
- */
-function matchUpcastDispatcherReceiver( node ) {
-	if ( !node ) {
-		return false;
-	}
-
-	if ( node.type === 'Identifier' && node.name === 'upcastDispatcher' ) {
-		return true;
-	}
-
-	return node.type === 'MemberExpression' &&
-		!node.computed &&
-		node.property.type === 'Identifier' &&
-		node.property.name === 'upcastDispatcher';
 }

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/require-explicit-data-context.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/require-explicit-data-context.js
@@ -37,6 +37,13 @@ const RULES = [
 		matchReceiver: matchWriterReceiver,
 		isMissingContext: args => args.length === 1,
 		label: 'writer.addRoot()'
+	},
+	{
+		// `upcastDispatcher.convert( viewElementOrFragment, writer, context = [ '$root' ] )` — third arg is the schema context.
+		method: 'convert',
+		matchReceiver: matchUpcastDispatcherReceiver,
+		isMissingContext: args => args.length === 2,
+		label: 'upcastDispatcher.convert()'
 	}
 ];
 
@@ -141,4 +148,24 @@ function matchDocumentReceiver( node ) {
  */
 function matchWriterReceiver( node ) {
 	return Boolean( node ) && node.type === 'Identifier' && node.name === 'writer';
+}
+
+/**
+ * Matches a receiver whose final accessed property is `upcastDispatcher` (e.g. `editor.data.upcastDispatcher`).
+ * The upcast dispatcher is the only API in the engine that exposes a `convert()` method with a defaulted schema
+ * context, so this filter excludes unrelated `*.convert()` calls without false positives.
+ */
+function matchUpcastDispatcherReceiver( node ) {
+	if ( !node ) {
+		return false;
+	}
+
+	if ( node.type === 'Identifier' && node.name === 'upcastDispatcher' ) {
+		return true;
+	}
+
+	return node.type === 'MemberExpression' &&
+		!node.computed &&
+		node.property.type === 'Identifier' &&
+		node.property.name === 'upcastDispatcher';
 }

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/require-explicit-data-context.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/require-explicit-data-context.js
@@ -5,30 +5,53 @@
 
 'use strict';
 
-const DEFAULT_METHODS = [ 'parse', 'toModel' ];
+// Methods whose API silently falls back to `$root` when the caller omits the schema/element-name argument.
+//
+// Each entry encodes:
+// - `method`           — the property name being called (used as the AST CallExpression callee filter).
+// - `matchReceiver`    — predicate that decides whether the call site's receiver matches the model-side variant
+//                        (e.g. `data.parse()` not `JSON.parse()`; `model.document.createRoot()` not a stray `*.createRoot()`).
+// - `isMissingContext` — predicate over the call's arguments. True when the schema/element-name argument is omitted.
+// - `label`            — short call shape used in the user-facing message.
+const RULES = [
+	{
+		method: 'parse',
+		matchReceiver: matchDataReceiver,
+		isMissingContext: args => args.length === 1,
+		label: 'data.parse()'
+	},
+	{
+		method: 'toModel',
+		matchReceiver: matchDataReceiver,
+		isMissingContext: args => args.length === 1,
+		label: 'data.toModel()'
+	},
+	{
+		method: 'createRoot',
+		matchReceiver: matchDocumentReceiver,
+		isMissingContext: args => args.length === 0,
+		label: 'document.createRoot()'
+	},
+	{
+		method: 'addRoot',
+		matchReceiver: matchWriterReceiver,
+		isMissingContext: args => args.length === 1,
+		label: 'writer.addRoot()'
+	}
+];
 
 module.exports = {
 	meta: {
 		type: 'problem',
 		docs: {
-			description: 'Require an explicit schema context when calling "data.parse()" / "data.toModel()".',
+			description:
+				'Require an explicit root element name / schema context when calling APIs that silently fall back to "$root".',
 			category: 'CKEditor5'
 		},
-		schema: [
-			{
-				type: 'object',
-				properties: {
-					methods: {
-						type: 'array',
-						items: { type: 'string' }
-					}
-				},
-				additionalProperties: false
-			}
-		],
+		schema: [],
 		messages: {
 			missingContext:
-				'Pass an explicit schema context to "data.{{ method }}()". Without it the API falls back to "$root", ' +
+				'Pass the root element name explicitly to "{{ label }}". Without it the API falls back to "$root", ' +
 				'which is silently wrong when "config.root.modelElement" is customised. ' +
 				'If you have verified that the default is acceptable here, opt out with an ' +
 				'"// eslint-disable-next-line" comment that explains why.'
@@ -36,33 +59,36 @@ module.exports = {
 	},
 
 	create( context ) {
-		const options = context.options[ 0 ] || {};
-		const methods = options.methods || DEFAULT_METHODS;
-
 		return {
 			CallExpression( node ) {
-				if ( node.arguments.length !== 1 ) {
-					return;
-				}
-
 				const callee = node.callee;
 
 				if ( !callee || callee.type !== 'MemberExpression' || callee.computed ) {
 					return;
 				}
 
-				if ( callee.property.type !== 'Identifier' || !methods.includes( callee.property.name ) ) {
+				if ( callee.property.type !== 'Identifier' ) {
 					return;
 				}
 
-				if ( !isDataReceiver( callee.object ) ) {
+				const rule = RULES.find( r => r.method === callee.property.name );
+
+				if ( !rule ) {
+					return;
+				}
+
+				if ( !rule.matchReceiver( callee.object ) ) {
+					return;
+				}
+
+				if ( !rule.isMissingContext( node.arguments ) ) {
 					return;
 				}
 
 				context.report( {
 					node,
 					messageId: 'missingContext',
-					data: { method: callee.property.name }
+					data: { label: rule.label }
 				} );
 			}
 		};
@@ -70,11 +96,10 @@ module.exports = {
 };
 
 /**
- * Whether the receiver looks like a `data` reference:
- * - a bare `Identifier` named `data` (covers `const { data } = editor; data.parse( … )`),
- * - or a `MemberExpression` whose final accessed property is `data` (covers `editor.data`, `this.data`, `foo.bar.data`, etc.).
+ * Matches `data`, `editor.data`, `this.data`, `foo.bar.data`, etc. — i.e. any reference whose final accessed property
+ * is `data`, plus a bare `data` identifier (covers destructured `const { data } = editor` patterns).
  */
-function isDataReceiver( node ) {
+function matchDataReceiver( node ) {
 	if ( !node ) {
 		return false;
 	}
@@ -83,9 +108,37 @@ function isDataReceiver( node ) {
 		return true;
 	}
 
-	if ( node.type === 'MemberExpression' && !node.computed && node.property.type === 'Identifier' && node.property.name === 'data' ) {
+	return node.type === 'MemberExpression' &&
+		!node.computed &&
+		node.property.type === 'Identifier' &&
+		node.property.name === 'data';
+}
+
+/**
+ * Matches a receiver whose final accessed property is `document` (e.g. `editor.model.document`, `this.model.document`).
+ * The model document is the only `document` in the engine that exposes `createRoot()`, so this filter is enough to
+ * exclude unrelated `*.createRoot()` calls without false positives.
+ */
+function matchDocumentReceiver( node ) {
+	if ( !node ) {
+		return false;
+	}
+
+	if ( node.type === 'Identifier' && node.name === 'document' ) {
 		return true;
 	}
 
-	return false;
+	return node.type === 'MemberExpression' &&
+		!node.computed &&
+		node.property.type === 'Identifier' &&
+		node.property.name === 'document';
+}
+
+/**
+ * Matches a receiver named `writer` (i.e. a `ModelWriter` from `model.change( writer => … )` or `model.enqueueChange`).
+ * Crucially this excludes `MultiRootEditor#addRoot( rootName, options? )` — that public API has a different
+ * second-arg shape (options object) and resolves the model element name internally, so it must not be flagged.
+ */
+function matchWriterReceiver( node ) {
+	return Boolean( node ) && node.type === 'Identifier' && node.name === 'writer';
 }

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-literal-dollar-root.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-literal-dollar-root.js
@@ -129,6 +129,17 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-literal-dollar-root', require(
 			code: 'this.listenTo( viewDocument, \'arrowKey\', handler, { \'context\': \'$root\' } );',
 			filename: featureFile,
 			options: allowlistOptions
+		},
+		// Other view-listener method names are also accepted.
+		{
+			code: 'view.on( \'arrowKey\', handler, { context: \'$root\' } );',
+			filename: featureFile,
+			options: allowlistOptions
+		},
+		{
+			code: 'emitter.once( \'arrowKey\', handler, { context: \'$root\' } );',
+			filename: featureFile,
+			options: allowlistOptions
 		}
 	],
 
@@ -278,6 +289,22 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-literal-dollar-root', require(
 		{
 			code: 'const ROOT = \'$root\';',
 			filename: engineFile,
+			errors: [ { messageId: 'literalDollarRoot' } ]
+		},
+
+		// `{ context: '$root' }` outside a view-listener call is NOT exempted — only `listenTo`/`on`/`once`/`off`
+		// receivers qualify. Any other API receiving an options object with `context` is flagged normally.
+		{
+			code: 'someApi( { context: \'$root\' } );',
+			filename: featureFile,
+			options: allowlistOptions,
+			errors: [ { messageId: 'literalDollarRoot' } ]
+		},
+		// Bare object literal not passed to any call — also flagged.
+		{
+			code: 'const opts = { context: \'$root\' };',
+			filename: featureFile,
+			options: allowlistOptions,
 			errors: [ { messageId: 'literalDollarRoot' } ]
 		}
 	]

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-literal-dollar-root.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-literal-dollar-root.js
@@ -191,6 +191,47 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-literal-dollar-root', require(
 			errors: [ { messageId: 'nameEqualsDollarRoot' } ]
 		},
 
+		// Pattern 1 with a logical-expression receiver — autofix skipped to avoid dropping parens and
+		// silently flipping `( a || b ).is( … )` into `a || b.is( … )`.
+		{
+			code: 'if ( ( a || b ).is( \'element\', \'$root\' ) ) {}',
+			output: null,
+			filename: featureFile,
+			options: allowlistOptions,
+			errors: [ { messageId: 'isElementDollarRoot' } ]
+		},
+		// Pattern 1 with a conditional-expression receiver — autofix skipped for the same reason.
+		{
+			code: 'if ( ( cond ? x : y ).is( \'element\', \'$root\' ) ) {}',
+			output: null,
+			filename: featureFile,
+			options: allowlistOptions,
+			errors: [ { messageId: 'isElementDollarRoot' } ]
+		},
+		// Pattern 2 with a logical-expression receiver — autofix skipped, but the message hint wraps the
+		// suggestion in parens so the rewrite text is itself valid.
+		{
+			code: 'if ( ( a || b ).name === \'$root\' ) {}',
+			output: null,
+			filename: featureFile,
+			options: allowlistOptions,
+			errors: [ {
+				messageId: 'nameEqualsDollarRoot',
+				data: { replacement: '( a || b ).is( \'rootElement\' )' }
+			} ]
+		},
+		// Pattern 2 (negated) with a conditional-expression receiver — autofix skipped, parens preserved in hint.
+		{
+			code: 'if ( ( cond ? x : y ).name !== \'$root\' ) {}',
+			output: null,
+			filename: featureFile,
+			options: allowlistOptions,
+			errors: [ {
+				messageId: 'nameEqualsDollarRoot',
+				data: { replacement: '!( cond ? x : y ).is( \'rootElement\' )' }
+			} ]
+		},
+
 		// Bare `$root` literal in a feature package.
 		{
 			code: 'const ROOT = \'$root\';',

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-literal-dollar-root.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-literal-dollar-root.js
@@ -1,0 +1,243 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const path = require( 'node:path' );
+const { RuleTester } = require( 'eslint' );
+
+const ruleTester = new RuleTester( {
+	languageOptions: {
+		sourceType: 'module',
+		ecmaVersion: 2020
+	}
+} );
+
+const allowlistOptions = [
+	{
+		allowedPackages: [ 'ckeditor5-engine', 'ckeditor5-core' ],
+		allowedCalls: [ 'is' ]
+	}
+];
+
+const featureFile = path.posix.join( '/', 'workspace', 'ckeditor5', 'packages', 'ckeditor5-paragraph', 'src', 'paragraph.js' );
+const engineFile = path.posix.join( '/', 'workspace', 'ckeditor5', 'packages', 'ckeditor5-engine', 'src', 'model', 'schema.js' );
+const coreFile = path.posix.join( '/', 'workspace', 'ckeditor5', 'packages', 'ckeditor5-core', 'src', 'editor.js' );
+
+ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-literal-dollar-root', require( '../../lib/rules/no-literal-dollar-root' ), {
+	valid: [
+		// Allowlisted package — engine can define `$root`.
+		{
+			code: 'schema.register( \'$root\', { isRoot: true } );',
+			filename: engineFile,
+			options: allowlistOptions
+		},
+		// Allowlisted package — core can reference `$root`.
+		{
+			code: 'const ROOT = \'$root\';',
+			filename: coreFile,
+			options: allowlistOptions
+		},
+		// Other schema contexts must not be flagged.
+		{
+			code: 'editor.data.parse( html, \'$documentFragment\' );',
+			filename: featureFile,
+			options: allowlistOptions
+		},
+		{
+			code: 'editor.data.parse( html, \'$clipboardHolder\' );',
+			filename: featureFile,
+			options: allowlistOptions
+		},
+		// Plain rootElement check, the recommended form.
+		{
+			code: 'if ( node.is( \'rootElement\' ) ) { /* … */ }',
+			filename: featureFile,
+			options: allowlistOptions
+		},
+		// Comments and JSDoc that mention `$root` must not be flagged (Literal handler ignores comments).
+		{
+			code:
+				'// $root is the default root element name in the engine.\n' +
+				'const name = \'paragraph\';\n',
+			filename: featureFile,
+			options: allowlistOptions
+		},
+		{
+			code:
+				'/**\n' +
+				' * Returns true for "$root".\n' +
+				' */\n' +
+				'function isRoot() { return true; }\n',
+			filename: featureFile,
+			options: allowlistOptions
+		},
+		// Template literal containing `$root` is not a string Literal node, so it is allowed.
+		{
+			code: 'const t = `$root is the default`;',
+			filename: featureFile,
+			options: allowlistOptions
+		},
+		// `allowedCalls` opt-out: `$root` inside a `.is()` argument list (single arg) is allowed.
+		// Note: the canonical bad form `.is('element', '$root')` is reported separately as `isElementDollarRoot`.
+		{
+			code: 'if ( node.is( \'$root\' ) ) {}',
+			filename: featureFile,
+			options: allowlistOptions
+		},
+		// Default options (empty allowlist) — engine code is still flagged, but bare valid usage of other strings is fine.
+		{
+			code: 'const t = \'paragraph\';',
+			filename: featureFile
+		},
+
+		// `schema.extend( '$root', { allowAttributes: … } )` — the documented escape hatch for adding attributes to the default root.
+		{
+			code: 'editor.model.schema.extend( \'$root\', { allowAttributes: properties } );',
+			filename: featureFile,
+			options: allowlistOptions
+		},
+		// Bare `schema` receiver, same shape.
+		{
+			code: 'schema.extend( \'$root\', { allowAttributes: [ \'foo\', \'bar\' ] } );',
+			filename: featureFile,
+			options: allowlistOptions
+		},
+		// String-keyed `allowAttributes` is also accepted.
+		{
+			code: 'schema.extend( \'$root\', { \'allowAttributes\': properties } );',
+			filename: featureFile,
+			options: allowlistOptions
+		},
+
+		// View-event listener `context` option — `'$root'` here is a view-tree bubbling target, not a schema name.
+		{
+			code: 'this.listenTo( viewDocument, \'arrowKey\', handler, { context: \'$root\' } );',
+			filename: featureFile,
+			options: allowlistOptions
+		},
+		// `context` as an array of view-tree predicates including `'$root'`.
+		{
+			code: 'this.listenTo( viewDocument, \'arrowKey\', handler, { context: [ isWidget, \'$root\' ] } );',
+			filename: featureFile,
+			options: allowlistOptions
+		},
+		// String-keyed `'context'`.
+		{
+			code: 'this.listenTo( viewDocument, \'arrowKey\', handler, { \'context\': \'$root\' } );',
+			filename: featureFile,
+			options: allowlistOptions
+		}
+	],
+
+	invalid: [
+		// Pattern 1: `.is( 'element', '$root' )` is autofixed to `.is( 'rootElement' )`.
+		{
+			code: 'if ( node.is( \'element\', \'$root\' ) ) {}',
+			output: 'if ( node.is( \'rootElement\' ) ) {}',
+			filename: featureFile,
+			options: allowlistOptions,
+			errors: [ { messageId: 'isElementDollarRoot' } ]
+		},
+		// Same pattern with `this` receiver.
+		{
+			code: 'this.is( \'element\', \'$root\' );',
+			output: 'this.is( \'rootElement\' );',
+			filename: featureFile,
+			options: allowlistOptions,
+			errors: [ { messageId: 'isElementDollarRoot' } ]
+		},
+		// Same pattern with optional chain receiver.
+		{
+			code: 'node?.is( \'element\', \'$root\' );',
+			output: 'node?.is( \'rootElement\' );',
+			filename: featureFile,
+			options: allowlistOptions,
+			errors: [ { messageId: 'isElementDollarRoot' } ]
+		},
+
+		// Pattern 2: `x.name === '$root'` autofixed to `x.is( 'rootElement' )`.
+		{
+			code: 'if ( node.name === \'$root\' ) {}',
+			output: 'if ( node.is( \'rootElement\' ) ) {}',
+			filename: featureFile,
+			options: allowlistOptions,
+			errors: [ { messageId: 'nameEqualsDollarRoot' } ]
+		},
+		// Pattern 2 (flipped operand order).
+		{
+			code: 'if ( \'$root\' === node.name ) {}',
+			output: 'if ( node.is( \'rootElement\' ) ) {}',
+			filename: featureFile,
+			options: allowlistOptions,
+			errors: [ { messageId: 'nameEqualsDollarRoot' } ]
+		},
+		// Pattern 2 (negated).
+		{
+			code: 'if ( node.name !== \'$root\' ) {}',
+			output: 'if ( !node.is( \'rootElement\' ) ) {}',
+			filename: featureFile,
+			options: allowlistOptions,
+			errors: [ { messageId: 'nameEqualsDollarRoot' } ]
+		},
+		// Pattern 2 with deeper receiver.
+		{
+			code: 'if ( editor.model.document.getRoot().name === \'$root\' ) {}',
+			output: 'if ( editor.model.document.getRoot().is( \'rootElement\' ) ) {}',
+			filename: featureFile,
+			options: allowlistOptions,
+			errors: [ { messageId: 'nameEqualsDollarRoot' } ]
+		},
+
+		// Bare `$root` literal in a feature package.
+		{
+			code: 'const ROOT = \'$root\';',
+			filename: featureFile,
+			options: allowlistOptions,
+			errors: [ { messageId: 'literalDollarRoot' } ]
+		},
+		// `schema.extend( '$root', … )` with extra keys beyond `allowAttributes` — escape hatch does not apply.
+		{
+			code: 'schema.extend( \'$root\', { allowAttributes: \'foo\', allowIn: \'paragraph\' } );',
+			filename: featureFile,
+			options: allowlistOptions,
+			errors: [ { messageId: 'literalDollarRoot' } ]
+		},
+		// `schema.extend( '$root', { allowChildren: … } )` — wrong key, still flagged.
+		{
+			code: 'schema.extend( \'$root\', { allowChildren: \'foo\' } );',
+			filename: featureFile,
+			options: allowlistOptions,
+			errors: [ { messageId: 'literalDollarRoot' } ]
+		},
+		// `schema.extend( '$root', { ...spread } )` — spread disqualifies (cannot statically verify key).
+		{
+			code: 'schema.extend( \'$root\', { ...rules } );',
+			filename: featureFile,
+			options: allowlistOptions,
+			errors: [ { messageId: 'literalDollarRoot' } ]
+		},
+		// `schema.extend( '$root', otherObj )` — non-object-literal second arg, still flagged.
+		{
+			code: 'schema.extend( \'$root\', otherRules );',
+			filename: featureFile,
+			options: allowlistOptions,
+			errors: [ { messageId: 'literalDollarRoot' } ]
+		},
+		// `writer.addRoot( _, '$root' )` — covered by the literal check.
+		{
+			code: 'writer.addRoot( newRoot, \'$root\' );',
+			filename: featureFile,
+			options: allowlistOptions,
+			errors: [ { messageId: 'literalDollarRoot' } ]
+		},
+		// Default options — engine file is flagged when `allowedPackages` is empty.
+		{
+			code: 'const ROOT = \'$root\';',
+			filename: engineFile,
+			errors: [ { messageId: 'literalDollarRoot' } ]
+		}
+	]
+} );

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/require-explicit-data-context.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/require-explicit-data-context.js
@@ -55,7 +55,13 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/require-explicit-data-context', r
 		// not `writer`. Must NOT be flagged: the method resolves its own default internally.
 		'editor.addRoot( \'myRoot\' );',
 		'this.addRoot( rootName );',
-		'multiRootEditor.addRoot( \'foo\' );'
+		'multiRootEditor.addRoot( \'foo\' );',
+
+		// Explicit context provided to upcastDispatcher.convert().
+		'editor.data.upcastDispatcher.convert( viewFragment, writer, [ \'$documentFragment\' ] );',
+		'this.editor.data.upcastDispatcher.convert( viewFragment, writer, root );',
+		// `convert` not on an `upcastDispatcher` receiver — out of scope.
+		'units.convert( value, fromUnit );'
 	],
 
 	invalid: [
@@ -104,6 +110,16 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/require-explicit-data-context', r
 		{
 			code: 'writer.addRoot( rootName );',
 			errors: [ { messageId: 'missingContext', data: { label: 'writer.addRoot()' } } ]
+		},
+
+		// `upcastDispatcher.convert( viewFragment, writer )` — context omitted.
+		{
+			code: 'editor.data.upcastDispatcher.convert( viewFragment, writer );',
+			errors: [ { messageId: 'missingContext', data: { label: 'upcastDispatcher.convert()' } } ]
+		},
+		{
+			code: 'this.editor.data.upcastDispatcher.convert( viewFragment, writer );',
+			errors: [ { messageId: 'missingContext', data: { label: 'upcastDispatcher.convert()' } } ]
 		}
 	]
 } );

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/require-explicit-data-context.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/require-explicit-data-context.js
@@ -18,64 +18,92 @@ const rule = require( '../../lib/rules/require-explicit-data-context' );
 
 ruleTester.run( 'eslint-plugin-ckeditor5-rules/require-explicit-data-context', rule, {
 	valid: [
-		// Explicit context provided.
+		// Explicit context provided to data.parse() / data.toModel().
 		'editor.data.parse( html, \'$documentFragment\' );',
 		'editor.data.toModel( view, \'$clipboardHolder\' );',
 		'this.data.parse( html, context );',
 		// Destructured `data` reference with explicit context.
 		'const { data } = editor; data.parse( html, \'$root\' );',
-		// No arguments — out of scope (different API misuse).
+		// No arguments — out of scope (different API misuse, not an omitted-context bug).
 		'editor.data.parse();',
-		// Method not in the list.
+		// Method not handled by this rule.
 		'editor.data.format( html );',
 		// Receiver is not `data`.
 		'editor.config.parse( raw );',
 		'JSON.parse( raw );',
 		'someOther.parse( html );',
+		'parser.parse( html );',
 		// Computed property access — not matched.
 		'editor[ \'data\' ].parse( html );',
-		// `parse` on something other than `data`.
-		'parser.parse( html );',
-		// Three or more arguments.
+		// Three or more arguments to parse — context is provided at index 1.
 		'editor.data.parse( html, \'$documentFragment\', extra );',
-		// Custom `methods` allowlist excludes `parse`.
-		{
-			code: 'editor.data.parse( html );',
-			options: [ { methods: [ 'toModel' ] } ]
-		}
+
+		// Explicit element name provided to createRoot.
+		'editor.model.document.createRoot( \'$inlineRoot\' );',
+		'editor.model.document.createRoot( \'$inlineRoot\', \'main\' );',
+		'this.model.document.createRoot( elementName );',
+		// `createRoot` not on a `document` receiver — out of scope.
+		'someUnrelated.createRoot();',
+
+		// Explicit element name provided to writer.addRoot.
+		'writer.addRoot( \'main\', \'$inlineRoot\' );',
+		'writer.addRoot( rootName, elementName );',
+		// `addRoot()` with no arguments — out of scope (rootName is required, this is a different bug).
+		'writer.addRoot();',
+
+		// `MultiRootEditor#addRoot( rootName, options? )` — different signature; receiver is `editor`/`this`/etc.,
+		// not `writer`. Must NOT be flagged: the method resolves its own default internally.
+		'editor.addRoot( \'myRoot\' );',
+		'this.addRoot( rootName );',
+		'multiRootEditor.addRoot( \'foo\' );'
 	],
 
 	invalid: [
-		// Canonical case: editor.data.parse( html ) without context.
+		// Canonical cases for data.parse() / data.toModel().
 		{
 			code: 'editor.data.parse( html );',
-			errors: [ { messageId: 'missingContext', data: { method: 'parse' } } ]
+			errors: [ { messageId: 'missingContext', data: { label: 'data.parse()' } } ]
 		},
-		// editor.data.toModel( view ) without context.
 		{
 			code: 'editor.data.toModel( view );',
-			errors: [ { messageId: 'missingContext', data: { method: 'toModel' } } ]
+			errors: [ { messageId: 'missingContext', data: { label: 'data.toModel()' } } ]
 		},
-		// `this.data.parse( html )`.
 		{
 			code: 'this.data.parse( html );',
-			errors: [ { messageId: 'missingContext', data: { method: 'parse' } } ]
+			errors: [ { messageId: 'missingContext', data: { label: 'data.parse()' } } ]
 		},
-		// Destructured `data` reference.
 		{
 			code: 'const { data } = editor; data.parse( html );',
-			errors: [ { messageId: 'missingContext', data: { method: 'parse' } } ]
+			errors: [ { messageId: 'missingContext', data: { label: 'data.parse()' } } ]
 		},
-		// Deep receiver chain.
 		{
 			code: 'foo.bar.editor.data.parse( html );',
-			errors: [ { messageId: 'missingContext', data: { method: 'parse' } } ]
+			errors: [ { messageId: 'missingContext', data: { label: 'data.parse()' } } ]
 		},
-		// Custom `methods` includes `convert`.
+
+		// `model.document.createRoot()` with no element name.
 		{
-			code: 'editor.data.convert( view );',
-			options: [ { methods: [ 'parse', 'toModel', 'convert' ] } ],
-			errors: [ { messageId: 'missingContext', data: { method: 'convert' } } ]
+			code: 'editor.model.document.createRoot();',
+			errors: [ { messageId: 'missingContext', data: { label: 'document.createRoot()' } } ]
+		},
+		{
+			code: 'this.model.document.createRoot();',
+			errors: [ { messageId: 'missingContext', data: { label: 'document.createRoot()' } } ]
+		},
+		// Bare `document.createRoot()` (covers destructured `const { document } = model` patterns).
+		{
+			code: 'document.createRoot();',
+			errors: [ { messageId: 'missingContext', data: { label: 'document.createRoot()' } } ]
+		},
+
+		// `writer.addRoot( rootName )` — element name omitted.
+		{
+			code: 'writer.addRoot( \'main\' );',
+			errors: [ { messageId: 'missingContext', data: { label: 'writer.addRoot()' } } ]
+		},
+		{
+			code: 'writer.addRoot( rootName );',
+			errors: [ { messageId: 'missingContext', data: { label: 'writer.addRoot()' } } ]
 		}
 	]
 } );

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/require-explicit-data-context.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/require-explicit-data-context.js
@@ -1,0 +1,81 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const { RuleTester } = require( 'eslint' );
+
+const ruleTester = new RuleTester( {
+	languageOptions: {
+		sourceType: 'module',
+		ecmaVersion: 2020
+	}
+} );
+
+const rule = require( '../../lib/rules/require-explicit-data-context' );
+
+ruleTester.run( 'eslint-plugin-ckeditor5-rules/require-explicit-data-context', rule, {
+	valid: [
+		// Explicit context provided.
+		'editor.data.parse( html, \'$documentFragment\' );',
+		'editor.data.toModel( view, \'$clipboardHolder\' );',
+		'this.data.parse( html, context );',
+		// Destructured `data` reference with explicit context.
+		'const { data } = editor; data.parse( html, \'$root\' );',
+		// No arguments — out of scope (different API misuse).
+		'editor.data.parse();',
+		// Method not in the list.
+		'editor.data.format( html );',
+		// Receiver is not `data`.
+		'editor.config.parse( raw );',
+		'JSON.parse( raw );',
+		'someOther.parse( html );',
+		// Computed property access — not matched.
+		'editor[ \'data\' ].parse( html );',
+		// `parse` on something other than `data`.
+		'parser.parse( html );',
+		// Three or more arguments.
+		'editor.data.parse( html, \'$documentFragment\', extra );',
+		// Custom `methods` allowlist excludes `parse`.
+		{
+			code: 'editor.data.parse( html );',
+			options: [ { methods: [ 'toModel' ] } ]
+		}
+	],
+
+	invalid: [
+		// Canonical case: editor.data.parse( html ) without context.
+		{
+			code: 'editor.data.parse( html );',
+			errors: [ { messageId: 'missingContext', data: { method: 'parse' } } ]
+		},
+		// editor.data.toModel( view ) without context.
+		{
+			code: 'editor.data.toModel( view );',
+			errors: [ { messageId: 'missingContext', data: { method: 'toModel' } } ]
+		},
+		// `this.data.parse( html )`.
+		{
+			code: 'this.data.parse( html );',
+			errors: [ { messageId: 'missingContext', data: { method: 'parse' } } ]
+		},
+		// Destructured `data` reference.
+		{
+			code: 'const { data } = editor; data.parse( html );',
+			errors: [ { messageId: 'missingContext', data: { method: 'parse' } } ]
+		},
+		// Deep receiver chain.
+		{
+			code: 'foo.bar.editor.data.parse( html );',
+			errors: [ { messageId: 'missingContext', data: { method: 'parse' } } ]
+		},
+		// Custom `methods` includes `convert`.
+		{
+			code: 'editor.data.convert( view );',
+			options: [ { methods: [ 'parse', 'toModel', 'convert' ] } ],
+			errors: [ { messageId: 'missingContext', data: { method: 'convert' } } ]
+		}
+	]
+} );


### PR DESCRIPTION
### 🚀 Summary

After the audit in [#20026](https://github.com/ckeditor/ckeditor5/issues/20026), most `'$root'` misuses fall into two patterns that are easy to introduce again:

1. A feature hardcodes `'$root'` as a schema context or element name — silently wrong when `config.root.modelElement` is customised.
2. A feature calls `editor.data.parse( html )` / `editor.data.toModel( view )` without an explicit `context` — picks up the API default, same failure mode.

Both are trivial code review misses. A lint rule can flag them at the source and force the author to either pass the right context or explicitly opt out with a justified `eslint-disable` comment.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5/issues/20096
* See https://github.com/ckeditor/ckeditor5/pull/20120

---

### 💡 Additional information

*Optional: Notes on decisions, edge cases, or anything helpful for reviewers.*
