### PR TITLE
`require-as-const-returns-in-methods` rule should only check `pluginName` method

### DIFF
--- a/.changelog/20260511175850_ci_4296_isolated_declarations_migration.md
+++ b/.changelog/20260511175850_ci_4296_isolated_declarations_migration.md
@@ -1,0 +1,7 @@
+---
+type: Major breaking change
+scope:
+  - eslint-plugin-ckeditor5-rules
+---
+
+The `ckeditor5-rules/require-as-const-returns-in-methods` rule now checks only the `pluginName` method.

--- a/packages/eslint-config-ckeditor5/eslint.config.mjs
+++ b/packages/eslint-config-ckeditor5/eslint.config.mjs
@@ -426,7 +426,7 @@ const rulesSourceCode = [
 			'ckeditor5-rules/allow-imports-only-from-main-package-entry-point': 'error',
 
 			'ckeditor5-rules/require-as-const-returns-in-methods': [ 'error', {
-				methodNames: [ 'requires', 'pluginName' ]
+				methodNames: [ 'pluginName' ]
 			} ],
 
 			'ckeditor5-rules/ckeditor-plugin-flags': [ 'error', {


### PR DESCRIPTION
### 🚀 Summary

The `require-as-const-returns-in-methods` rule should only check the `pluginName` method.

---

### 📌 Related issues

* See https://github.com/ckeditor/ckeditor5-internal/issues/4296#issuecomment-4487231132.

---

### 💡 Additional information

N/A
