### PR TITLE
EOF enforcement.

### DIFF
--- a/.changelog/20260526103431_ci_4485.md
+++ b/.changelog/20260526103431_ci_4485.md
@@ -1,0 +1,9 @@
+---
+type: Major breaking change
+scope:
+  - eslint-config-ckeditor5
+closes:
+  - https://github.com/ckeditor/ckeditor5-internal/issues/4485
+---
+
+Updated the `@stylistic/no-multiple-empty-lines` rule in default config to enforce a single empty line at the beginning and end of files.

--- a/packages/eslint-config-ckeditor5/eslint.config.mjs
+++ b/packages/eslint-config-ckeditor5/eslint.config.mjs
@@ -212,7 +212,9 @@ const rulesGeneral = [
 			'@stylistic/new-parens': 'error',
 
 			'@stylistic/no-multiple-empty-lines': [ 'error', {
-				max: 1
+				max: 1,
+				maxBOF: 0,
+				maxEOF: 0
 			} ],
 
 			'@stylistic/no-trailing-spaces': 'error',

--- a/scripts/ci/is-project-ready-to-release.mjs
+++ b/scripts/ci/is-project-ready-to-release.mjs
@@ -23,4 +23,3 @@ releaseTools.isVersionPublishableForTag( packageName, changelogVersion, npmTag )
 			console.log( 'The project is ready to release.' );
 		}
 	} );
-


### PR DESCRIPTION
<!--

This repository uses Markdown files to define changelog entries. If the changes in this pull request are **user-facing**, please create a changelog entry by running the following command:

    pnpm run nice

This will generate a `*.md` file in the `.changelog/` directory for your description. You can create as many as you need.

**Note:**
If your PR is internal-only (e.g., tests, tooling, docs), you can skip this step - just mention it below.

-->

### 🚀 Summary

Updated the `@stylistic/no-multiple-empty-lines` rule in default config to enforce a single empty line at the beginning and end of files.

---

### 📌 Related issues

<!--

Although changelog entries list connected issues, GitHub requires listing them here to automatically link and close them.

-->

* Closes https://github.com/ckeditor/ckeditor5-internal/issues/4485.

---

### 💡 Additional information

<details>
  <summary><code>pnpm run lint</code> in <code>ckeditor5</code></summary>

```bash
pnpm run lint

> ckeditor5-root@48.1.1 lint home/repositories/ckeditor5
> eslint --format ./scripts/eslint-formatter.cjs --concurrency=4


home/repositories/ckeditor5/docs/_snippets/framework/development-tools/inspector.js
  39:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/docs/_snippets/installation/getting-and-setting-data/build-autosave-source.js
  27:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/docs/_snippets/tutorials/abbreviation-level-1.js
  109:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/docs/_snippets/tutorials/abbreviation-level-2.js
  195:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/docs/_snippets/tutorials/abbreviation-level-3.js
  346:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/docs/_snippets/tutorials/timestamp-plugin.js
  63:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-alignment/docs/_snippets/features/text-alignment.js
  58:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-ckbox/tests/ckbox.js
  69:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-code-block/src/codeblockconfig.ts
  159:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-emoji/tests/manual/emoji.js
  167:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-arbitrary-attribute-values.js
  76:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-engine/tests/manual/tickets/10430/1.js
  86:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-engine/tests/manual/view/focus.js
  49:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-engine/tests/manual/view/inline-filler.js
  30:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-engine/tests/manual/view/keyobserver.js
  26:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-engine/tests/manual/view/uielement.js
  83:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-essentials/src/augmentation.ts
  13:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-fullscreen/src/augmentation.ts
  34:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-heading/tests/headingediting.js
  262:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-image/src/image/converters.ts
  313:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-image/tests/imagestyle/imagestyleui.js
  559:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-image/tests/manual/imageplaceholder.js
  28:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-image/tests/manual/imagestyle.js
  118:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-image/tests/manual/imageupload.js
  103:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-link/tests/integrations/clipboard.js
  163:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-link/tests/manual/linkdecorator.js
  206:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-media-embed/src/mediaembedtoolbar.ts
  79:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-minimap/src/augmentation.ts
  26:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-paste-from-office/tests/_data/paste-from-google-docs/br-paragraph/index.js
  21:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-restricted-editing/src/standardeditingmode.ts
  44:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-table/tests/manual/tablelayout-configurable.js
  553:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-ui/tests/focuscycler.js
  1149:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-ui/tests/manual/list/list.js
  58:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-ui/tests/manual/tickets/5328/1.js
  121:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-ui/tests/spinner/spinner.js
  44:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-widget/tests/manual/type-around.js
  157:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5-word-count/docs/_snippets/features/word-count-update.js
  100:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5/tests/manual/abbreviation-level-1.js
  103:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5/tests/manual/abbreviation-level-2.js
  170:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/packages/ckeditor5/tests/manual/abbreviation-level-3.js
  327:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

home/repositories/ckeditor5/scripts-tests/release/utils/istypescriptpackage.mjs
  31:1  error  Too many blank lines at the end of file. Max of 0 allowed  @stylistic/no-multiple-empty-lines

✖ 41 problems (41 errors, 0 warnings)
  41 errors and 0 warnings potentially fixable with the `--fix` option.

 ELIFECYCLE  Command failed with exit code 1.

```

</details>

<details>
  <summary><code>git diff</code> after <code>pnpm run lint --fix</code> in <code>ckeditor5</code></summary>

```diff
diff --git a/ckeditor5/docs/_snippets/framework/development-tools/inspector.js b/ckeditor5/docs/_snippets/framework/development-tools/inspector.js
index 7340ab23a83..4ca22211829 100644
--- a/ckeditor5/docs/_snippets/framework/development-tools/inspector.js
+++ b/ckeditor5/docs/_snippets/framework/development-tools/inspector.js
@@ -36,4 +36,3 @@ ClassicEditor
 	.catch( err => {
 		console.error( err );
 	} );
-
diff --git a/ckeditor5/docs/_snippets/installation/getting-and-setting-data/build-autosave-source.js b/ckeditor5/docs/_snippets/installation/getting-and-setting-data/build-autosave-source.js
index 418a9877569..4ace27fec91 100644
--- a/ckeditor5/docs/_snippets/installation/getting-and-setting-data/build-autosave-source.js
+++ b/ckeditor5/docs/_snippets/installation/getting-and-setting-data/build-autosave-source.js
@@ -24,4 +24,3 @@ export class AutosaveEditor extends ClassicEditor {
 		AutoImage
 	];
 }
-
diff --git a/ckeditor5/docs/_snippets/tutorials/abbreviation-level-1.js b/ckeditor5/docs/_snippets/tutorials/abbreviation-level-1.js
index 9577b1f6214..8a7e5536ed0 100644
--- a/ckeditor5/docs/_snippets/tutorials/abbreviation-level-1.js
+++ b/ckeditor5/docs/_snippets/tutorials/abbreviation-level-1.js
@@ -106,4 +106,3 @@ ClassicEditor
 	.catch( err => {
 		console.error( err );
 	} );
-
diff --git a/ckeditor5/docs/_snippets/tutorials/abbreviation-level-2.js b/ckeditor5/docs/_snippets/tutorials/abbreviation-level-2.js
index 67058aa4115..f64377942ce 100644
--- a/ckeditor5/docs/_snippets/tutorials/abbreviation-level-2.js
+++ b/ckeditor5/docs/_snippets/tutorials/abbreviation-level-2.js
@@ -192,4 +192,3 @@ ClassicEditor
 	.catch( err => {
 		console.error( err );
 	} );
-
diff --git a/ckeditor5/docs/_snippets/tutorials/abbreviation-level-3.js b/ckeditor5/docs/_snippets/tutorials/abbreviation-level-3.js
index 4a7710389e5..0b867773acd 100644
--- a/ckeditor5/docs/_snippets/tutorials/abbreviation-level-3.js
+++ b/ckeditor5/docs/_snippets/tutorials/abbreviation-level-3.js
@@ -343,4 +343,3 @@ ClassicEditor
 	.catch( err => {
 		console.error( err );
 	} );
-
diff --git a/ckeditor5/docs/_snippets/tutorials/timestamp-plugin.js b/ckeditor5/docs/_snippets/tutorials/timestamp-plugin.js
index 5b7797a98be..af8ba51fd5d 100644
--- a/ckeditor5/docs/_snippets/tutorials/timestamp-plugin.js
+++ b/ckeditor5/docs/_snippets/tutorials/timestamp-plugin.js
@@ -60,4 +60,3 @@ ClassicEditor
 	.catch( err => {
 		console.error( err );
 	} );
-
diff --git a/ckeditor5/packages/ckeditor5-alignment/docs/_snippets/features/text-alignment.js b/ckeditor5/packages/ckeditor5-alignment/docs/_snippets/features/text-alignment.js
index 99128462802..2e25694968d 100644
--- a/ckeditor5/packages/ckeditor5-alignment/docs/_snippets/features/text-alignment.js
+++ b/ckeditor5/packages/ckeditor5-alignment/docs/_snippets/features/text-alignment.js
@@ -55,4 +55,3 @@ TextAlignmentEditor
 	.catch( err => {
 		console.error( err.stack );
 	} );
-
diff --git a/ckeditor5/packages/ckeditor5-ckbox/tests/ckbox.js b/ckeditor5/packages/ckeditor5-ckbox/tests/ckbox.js
index 6c3f7a219dd..92fbc029949 100644
--- a/ckeditor5/packages/ckeditor5-ckbox/tests/ckbox.js
+++ b/ckeditor5/packages/ckeditor5-ckbox/tests/ckbox.js
@@ -66,4 +66,3 @@ describe( 'CKBox', () => {
 		expect( CKBox.isPremiumPlugin ).to.be.false;
 	} );
 } );
-
diff --git a/ckeditor5/packages/ckeditor5-code-block/src/codeblockconfig.ts b/ckeditor5/packages/ckeditor5-code-block/src/codeblockconfig.ts
index eadb11475b0..963dec01830 100644
--- a/ckeditor5/packages/ckeditor5-code-block/src/codeblockconfig.ts
+++ b/ckeditor5/packages/ckeditor5-code-block/src/codeblockconfig.ts
@@ -156,4 +156,3 @@ export interface CodeBlockLanguageDefinition {
 	 */
 	class?: string;
 }
-
diff --git a/ckeditor5/packages/ckeditor5-emoji/tests/manual/emoji.js b/ckeditor5/packages/ckeditor5-emoji/tests/manual/emoji.js
index 64e83e5c5b7..bd78f4111bc 100644
--- a/ckeditor5/packages/ckeditor5-emoji/tests/manual/emoji.js
+++ b/ckeditor5/packages/ckeditor5-emoji/tests/manual/emoji.js
@@ -164,4 +164,3 @@ function getEditorConfig( { extraPlugins, emojiButtonInToolbar = true, root = {}
 		}
 	};
 }
-
diff --git a/ckeditor5/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-arbitrary-attribute-values.js b/ckeditor5/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-arbitrary-attribute-values.js
index 6127e783740..f805a999f76 100644
--- a/ckeditor5/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-arbitrary-attribute-values.js
+++ b/ckeditor5/packages/ckeditor5-engine/docs/_snippets/framework/extending-content-arbitrary-attribute-values.js
@@ -73,4 +73,3 @@ ClassicEditor
 	.catch( err => {
 		console.error( err.stack );
 	} );
-
diff --git a/ckeditor5/packages/ckeditor5-engine/tests/manual/tickets/10430/1.js b/ckeditor5/packages/ckeditor5-engine/tests/manual/tickets/10430/1.js
index b455b69d559..aca151bb28d 100644
--- a/ckeditor5/packages/ckeditor5-engine/tests/manual/tickets/10430/1.js
+++ b/ckeditor5/packages/ckeditor5-engine/tests/manual/tickets/10430/1.js
@@ -83,4 +83,3 @@ ClassicEditor
 	.catch( error => {
 		console.error( error.stack );
 	} );
-
diff --git a/ckeditor5/packages/ckeditor5-engine/tests/manual/view/focus.js b/ckeditor5/packages/ckeditor5-engine/tests/manual/view/focus.js
index 91f1c145462..bbd4a269946 100644
--- a/ckeditor5/packages/ckeditor5-engine/tests/manual/view/focus.js
+++ b/ckeditor5/packages/ckeditor5-engine/tests/manual/view/focus.js
@@ -46,4 +46,3 @@ document.getElementById( 'button2' ).addEventListener( 'click', () => {
 
 	view.focus();
 } );
-
diff --git a/ckeditor5/packages/ckeditor5-engine/tests/manual/view/inline-filler.js b/ckeditor5/packages/ckeditor5-engine/tests/manual/view/inline-filler.js
index abc11fe2e6d..3eb8229ff45 100644
--- a/ckeditor5/packages/ckeditor5-engine/tests/manual/view/inline-filler.js
+++ b/ckeditor5/packages/ckeditor5-engine/tests/manual/view/inline-filler.js
@@ -27,4 +27,3 @@ viewDocument.on( 'selectionChange', ( evt, data ) => {
 		writer.setSelection( data.newSelection );
 	} );
 } );
-
diff --git a/ckeditor5/packages/ckeditor5-engine/tests/manual/view/keyobserver.js b/ckeditor5/packages/ckeditor5-engine/tests/manual/view/keyobserver.js
index 0ccc65576fa..5a4d5d06a91 100644
--- a/ckeditor5/packages/ckeditor5-engine/tests/manual/view/keyobserver.js
+++ b/ckeditor5/packages/ckeditor5-engine/tests/manual/view/keyobserver.js
@@ -23,4 +23,3 @@ view.change( writer => {
 } );
 
 view.focus();
-
diff --git a/ckeditor5/packages/ckeditor5-engine/tests/manual/view/uielement.js b/ckeditor5/packages/ckeditor5-engine/tests/manual/view/uielement.js
index be71cdf2dcf..54844b7729b 100644
--- a/ckeditor5/packages/ckeditor5-engine/tests/manual/view/uielement.js
+++ b/ckeditor5/packages/ckeditor5-engine/tests/manual/view/uielement.js
@@ -80,4 +80,3 @@ ClassicEditor
 	.catch( err => {
 		console.error( err.stack );
 	} );
-
diff --git a/ckeditor5/packages/ckeditor5-essentials/src/augmentation.ts b/ckeditor5/packages/ckeditor5-essentials/src/augmentation.ts
index 9e11e6dfdfd..8955e2501ba 100644
--- a/ckeditor5/packages/ckeditor5-essentials/src/augmentation.ts
+++ b/ckeditor5/packages/ckeditor5-essentials/src/augmentation.ts
@@ -10,4 +10,3 @@ declare module '@ckeditor/ckeditor5-core' {
 		[ Essentials.pluginName ]: Essentials;
 	}
 }
-
diff --git a/ckeditor5/packages/ckeditor5-fullscreen/src/augmentation.ts b/ckeditor5/packages/ckeditor5-fullscreen/src/augmentation.ts
index d33d305f3db..5a321755303 100644
--- a/ckeditor5/packages/ckeditor5-fullscreen/src/augmentation.ts
+++ b/ckeditor5/packages/ckeditor5-fullscreen/src/augmentation.ts
@@ -31,4 +31,3 @@ declare module '@ckeditor/ckeditor5-core' {
 		toggleFullscreen: FullscreenCommand;
 	}
 }
-
diff --git a/ckeditor5/packages/ckeditor5-heading/tests/headingediting.js b/ckeditor5/packages/ckeditor5-heading/tests/headingediting.js
index b709195752a..15a34f0f4ff 100644
--- a/ckeditor5/packages/ckeditor5-heading/tests/headingediting.js
+++ b/ckeditor5/packages/ckeditor5-heading/tests/headingediting.js
@@ -259,4 +259,3 @@ describe( 'HeadingEditing', () => {
 		} );
 	} );
 } );
-
diff --git a/ckeditor5/packages/ckeditor5-image/src/image/converters.ts b/ckeditor5/packages/ckeditor5-image/src/image/converters.ts
index 0d1c199036b..544204d573a 100644
--- a/ckeditor5/packages/ckeditor5-image/src/image/converters.ts
+++ b/ckeditor5/packages/ckeditor5-image/src/image/converters.ts
@@ -310,4 +310,3 @@ export function downcastImageAttribute(
 		dispatcher.on<DowncastAttributeEvent<ModelElement>>( `attribute:${ attributeKey }:${ imageType }`, converter );
 	};
 }
-
diff --git a/ckeditor5/packages/ckeditor5-image/tests/imagestyle/imagestyleui.js b/ckeditor5/packages/ckeditor5-image/tests/imagestyle/imagestyleui.js
index 8517fdfa307..d33d0349a39 100644
--- a/ckeditor5/packages/ckeditor5-image/tests/imagestyle/imagestyleui.js
+++ b/ckeditor5/packages/ckeditor5-image/tests/imagestyle/imagestyleui.js
@@ -556,4 +556,3 @@ describe( 'ImageStyleUI', () => {
 		} );
 	} );
 } );
-
diff --git a/ckeditor5/packages/ckeditor5-image/tests/manual/imageplaceholder.js b/ckeditor5/packages/ckeditor5-image/tests/manual/imageplaceholder.js
index ae0eb8e4d10..2c929c9ed6f 100644
--- a/ckeditor5/packages/ckeditor5-image/tests/manual/imageplaceholder.js
+++ b/ckeditor5/packages/ckeditor5-image/tests/manual/imageplaceholder.js
@@ -25,4 +25,3 @@ ClassicEditor.create( {
 	.catch( error => {
 		console.error( error );
 	} );
-
diff --git a/ckeditor5/packages/ckeditor5-image/tests/manual/imagestyle.js b/ckeditor5/packages/ckeditor5-image/tests/manual/imagestyle.js
index 852966b4a56..0abb3ae2d4b 100644
--- a/ckeditor5/packages/ckeditor5-image/tests/manual/imagestyle.js
+++ b/ckeditor5/packages/ckeditor5-image/tests/manual/imagestyle.js
@@ -115,4 +115,3 @@ function bindPreview( editor, previewId ) {
 
 	preview.innerHTML = editor.getData();
 }
-
diff --git a/ckeditor5/packages/ckeditor5-image/tests/manual/imageupload.js b/ckeditor5/packages/ckeditor5-image/tests/manual/imageupload.js
index 9ee7a1b842b..5d5488663a2 100644
--- a/ckeditor5/packages/ckeditor5-image/tests/manual/imageupload.js
+++ b/ckeditor5/packages/ckeditor5-image/tests/manual/imageupload.js
@@ -100,4 +100,3 @@ function createProgressButton( loader, adapterMock ) {
 		}
 	} );
 }
-
diff --git a/ckeditor5/packages/ckeditor5-link/tests/integrations/clipboard.js b/ckeditor5/packages/ckeditor5-link/tests/integrations/clipboard.js
index 5a9704aa5c1..2817a706c09 100644
--- a/ckeditor5/packages/ckeditor5-link/tests/integrations/clipboard.js
+++ b/ckeditor5/packages/ckeditor5-link/tests/integrations/clipboard.js
@@ -160,4 +160,3 @@ describe( 'Link integration: clipboard paste', () => {
 		} );
 	} );
 } );
-
diff --git a/ckeditor5/packages/ckeditor5-link/tests/manual/linkdecorator.js b/ckeditor5/packages/ckeditor5-link/tests/manual/linkdecorator.js
index f501b442012..d81b19b82de 100644
--- a/ckeditor5/packages/ckeditor5-link/tests/manual/linkdecorator.js
+++ b/ckeditor5/packages/ckeditor5-link/tests/manual/linkdecorator.js
@@ -203,4 +203,3 @@ ClassicEditor
 	.catch( err => {
 		console.error( err.stack );
 	} );
-
diff --git a/ckeditor5/packages/ckeditor5-media-embed/src/mediaembedtoolbar.ts b/ckeditor5/packages/ckeditor5-media-embed/src/mediaembedtoolbar.ts
index e9e45c99e97..186f0efc234 100644
--- a/ckeditor5/packages/ckeditor5-media-embed/src/mediaembedtoolbar.ts
+++ b/ckeditor5/packages/ckeditor5-media-embed/src/mediaembedtoolbar.ts
@@ -76,4 +76,3 @@ function normalizeDeclarativeConfig(
 			typeof item !== 'string' || !item.startsWith( 'mediaEmbed:' ) || factory.has( item )
 		);
 }
-
diff --git a/ckeditor5/packages/ckeditor5-minimap/src/augmentation.ts b/ckeditor5/packages/ckeditor5-minimap/src/augmentation.ts
index f178cef2c9f..e8c181269cd 100644
--- a/ckeditor5/packages/ckeditor5-minimap/src/augmentation.ts
+++ b/ckeditor5/packages/ckeditor5-minimap/src/augmentation.ts
@@ -23,4 +23,3 @@ declare module '@ckeditor/ckeditor5-core' {
 		[ Minimap.pluginName ]: Minimap;
 	}
 }
-
diff --git a/ckeditor5/packages/ckeditor5-paste-from-office/tests/_data/paste-from-google-docs/br-paragraph/index.js b/ckeditor5/packages/ckeditor5-paste-from-office/tests/_data/paste-from-google-docs/br-paragraph/index.js
index 5841746eddb..6a8ca0eec99 100644
--- a/ckeditor5/packages/ckeditor5-paste-from-office/tests/_data/paste-from-google-docs/br-paragraph/index.js
+++ b/ckeditor5/packages/ckeditor5-paste-from-office/tests/_data/paste-from-google-docs/br-paragraph/index.js
@@ -18,4 +18,3 @@ export const fixtures = {
 		simpleParagraphs: simpleParagraphsModel
 	}
 };
-
diff --git a/ckeditor5/packages/ckeditor5-restricted-editing/src/standardeditingmode.ts b/ckeditor5/packages/ckeditor5-restricted-editing/src/standardeditingmode.ts
index 9dda11062d9..6bc37d68874 100644
--- a/ckeditor5/packages/ckeditor5-restricted-editing/src/standardeditingmode.ts
+++ b/ckeditor5/packages/ckeditor5-restricted-editing/src/standardeditingmode.ts
@@ -41,4 +41,3 @@ export class StandardEditingMode extends Plugin {
 		return [ StandardEditingModeEditing, StandardEditingModeUI ] as const;
 	}
 }
-
diff --git a/ckeditor5/packages/ckeditor5-table/tests/manual/tablelayout-configurable.js b/ckeditor5/packages/ckeditor5-table/tests/manual/tablelayout-configurable.js
index a88dd0a57f8..c870de65d72 100644
--- a/ckeditor5/packages/ckeditor5-table/tests/manual/tablelayout-configurable.js
+++ b/ckeditor5/packages/ckeditor5-table/tests/manual/tablelayout-configurable.js
@@ -550,4 +550,3 @@ tableTypeSelect.addEventListener( 'change', async () => {
 
 	window.editor = editor;
 } );
-
diff --git a/ckeditor5/packages/ckeditor5-ui/tests/focuscycler.js b/ckeditor5/packages/ckeditor5-ui/tests/focuscycler.js
index e60921c5657..1cf9143595e 100644
--- a/ckeditor5/packages/ckeditor5-ui/tests/focuscycler.js
+++ b/ckeditor5/packages/ckeditor5-ui/tests/focuscycler.js
@@ -1146,4 +1146,3 @@ describe( 'FocusCycler', () => {
 		return { focusCycler, focusTracker, focusables };
 	}
 } );
-
diff --git a/ckeditor5/packages/ckeditor5-ui/tests/manual/list/list.js b/ckeditor5/packages/ckeditor5-ui/tests/manual/list/list.js
index 88ac1a88ed2..a27ac6fa46e 100644
--- a/ckeditor5/packages/ckeditor5-ui/tests/manual/list/list.js
+++ b/ckeditor5/packages/ckeditor5-ui/tests/manual/list/list.js
@@ -55,4 +55,3 @@ function createGroup( label, items ) {
 
 	return groupView;
 }
-
diff --git a/ckeditor5/packages/ckeditor5-ui/tests/manual/tickets/5328/1.js b/ckeditor5/packages/ckeditor5-ui/tests/manual/tickets/5328/1.js
index 9f0ba36c6ed..c983a01eb34 100644
--- a/ckeditor5/packages/ckeditor5-ui/tests/manual/tickets/5328/1.js
+++ b/ckeditor5/packages/ckeditor5-ui/tests/manual/tickets/5328/1.js
@@ -118,4 +118,3 @@ ClassicEditor
 	.catch( err => {
 		console.error( err.stack );
 	} );
-
diff --git a/ckeditor5/packages/ckeditor5-ui/tests/spinner/spinner.js b/ckeditor5/packages/ckeditor5-ui/tests/spinner/spinner.js
index 376c5d5a844..243af53dfe3 100644
--- a/ckeditor5/packages/ckeditor5-ui/tests/spinner/spinner.js
+++ b/ckeditor5/packages/ckeditor5-ui/tests/spinner/spinner.js
@@ -41,4 +41,3 @@ describe( 'SpinnerView', () => {
 		} );
 	} );
 } );
-
diff --git a/ckeditor5/packages/ckeditor5-widget/tests/manual/type-around.js b/ckeditor5/packages/ckeditor5-widget/tests/manual/type-around.js
index 4d3f739d249..8b80bd6bcc1 100644
--- a/ckeditor5/packages/ckeditor5-widget/tests/manual/type-around.js
+++ b/ckeditor5/packages/ckeditor5-widget/tests/manual/type-around.js
@@ -154,4 +154,3 @@ ClassicEditor
 	.catch( err => {
 		console.error( err.stack );
 	} );
-
diff --git a/ckeditor5/packages/ckeditor5-word-count/docs/_snippets/features/word-count-update.js b/ckeditor5/packages/ckeditor5-word-count/docs/_snippets/features/word-count-update.js
index 75778e1f4fe..123d96a2ce7 100644
--- a/ckeditor5/packages/ckeditor5-word-count/docs/_snippets/features/word-count-update.js
+++ b/ckeditor5/packages/ckeditor5-word-count/docs/_snippets/features/word-count-update.js
@@ -97,4 +97,3 @@ BalloonEditor
 	.catch( err => {
 		console.error( err.stack );
 	} );
-
diff --git a/ckeditor5/packages/ckeditor5/tests/manual/abbreviation-level-1.js b/ckeditor5/packages/ckeditor5/tests/manual/abbreviation-level-1.js
index 34fa7bad31b..502f8d5e6bd 100644
--- a/ckeditor5/packages/ckeditor5/tests/manual/abbreviation-level-1.js
+++ b/ckeditor5/packages/ckeditor5/tests/manual/abbreviation-level-1.js
@@ -100,4 +100,3 @@ ClassicEditor
 	.catch( err => {
 		console.error( err );
 	} );
-
diff --git a/ckeditor5/packages/ckeditor5/tests/manual/abbreviation-level-2.js b/ckeditor5/packages/ckeditor5/tests/manual/abbreviation-level-2.js
index 71557c646fe..1b4946ceb44 100644
--- a/ckeditor5/packages/ckeditor5/tests/manual/abbreviation-level-2.js
+++ b/ckeditor5/packages/ckeditor5/tests/manual/abbreviation-level-2.js
@@ -167,4 +167,3 @@ ClassicEditor
 	.catch( err => {
 		console.error( err );
 	} );
-
diff --git a/ckeditor5/packages/ckeditor5/tests/manual/abbreviation-level-3.js b/ckeditor5/packages/ckeditor5/tests/manual/abbreviation-level-3.js
index 9a14001957f..5f7255644ed 100644
--- a/ckeditor5/packages/ckeditor5/tests/manual/abbreviation-level-3.js
+++ b/ckeditor5/packages/ckeditor5/tests/manual/abbreviation-level-3.js
@@ -324,4 +324,3 @@ ClassicEditor
 	.catch( err => {
 		console.error( err );
 	} );
-
diff --git a/ckeditor5/scripts-tests/release/utils/istypescriptpackage.mjs b/ckeditor5/scripts-tests/release/utils/istypescriptpackage.mjs
index 3843d953273..a8d6df1cfb4 100644
--- a/ckeditor5/scripts-tests/release/utils/istypescriptpackage.mjs
+++ b/ckeditor5/scripts-tests/release/utils/istypescriptpackage.mjs
@@ -28,4 +28,3 @@ describe( 'scripts/release/utils/istypescriptpackage', () => {
 		expect( result ).toBe( false );
 	} );
 } );
-

```

</details>
