### PR TITLE
Allow subpaths in `allow-imports-only-from-main-package-entry-point`

### DIFF
--- a/.changelog/20260623144246_ci_4544_dev_private_build_modernization.md
+++ b/.changelog/20260623144246_ci_4544_dev_private_build_modernization.md
@@ -1,0 +1,7 @@
+---
+type: Fix
+scope:
+  - eslint-plugin-ckeditor5-rules
+---
+
+The `allow-imports-only-from-main-package-entry-point` ESLint rule now allows imports from explicitly exported package subpaths declared in `package.json`.

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-imports-only-from-main-package-entry-point.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-imports-only-from-main-package-entry-point.js
@@ -91,7 +91,7 @@ function isExportedPackageSubpath( importPath, packageName, context ) {
 		const packageJson = readPackageJson( packageJsonPath );
 		const subpath = `.${ importPath.slice( packageName.length ) }`;
 
-		if ( !Object.hasOwn( packageJson.exports, subpath ) ) {
+		if ( !packageJson?.exports ) {
 			return false;
 		}
 

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-imports-only-from-main-package-entry-point.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-imports-only-from-main-package-entry-point.js
@@ -5,7 +5,13 @@
 
 'use strict';
 
+const fs = require( 'node:fs' );
+const { findPackageJSON } = require( 'node:module' );
+const { pathToFileURL } = require( 'node:url' );
+const resolveExports = require( 'resolve.exports' ).exports;
+
 const message = 'Importing from "@ckeditor/*" packages is only allowed from the main package entry point.';
+const packageJsonCache = new Map();
 
 module.exports = {
 	meta: {
@@ -37,6 +43,11 @@ module.exports = {
 
 				if ( path === match[ 0 ] ) {
 					// Ignore imports from the main package entry point.
+					return;
+				}
+
+				if ( isExportedPackageSubpath( path, match[ 0 ], context ) ) {
+					// Ignore imports from package subpaths explicitly defined in the `exports` field.
 					return;
 				}
 
@@ -73,3 +84,33 @@ module.exports = {
 		};
 	}
 };
+
+function isExportedPackageSubpath( importPath, packageName, context ) {
+	try {
+		const packageJsonPath = findPackageJSON( importPath, pathToFileURL( context.physicalFilename ) );
+		const packageJson = readPackageJson( packageJsonPath );
+		const subpath = `.${ importPath.slice( packageName.length ) }`;
+
+		if ( !Object.hasOwn( packageJson.exports, subpath ) ) {
+			return false;
+		}
+
+		resolveExports( packageJson, subpath );
+
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function readPackageJson( packageJsonPath ) {
+	if ( !packageJsonCache.has( packageJsonPath ) ) {
+		try {
+			packageJsonCache.set( packageJsonPath, JSON.parse( fs.readFileSync( packageJsonPath, 'utf8' ) ) );
+		} catch {
+			packageJsonCache.set( packageJsonPath, null );
+		}
+	}
+
+	return packageJsonCache.get( packageJsonPath );
+}

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/allow-imports-only-from-main-package-entry-point.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/allow-imports-only-from-main-package-entry-point.js
@@ -11,10 +11,8 @@ const path = require( 'node:path' );
 
 const message = 'Importing from "@ckeditor/*" packages is only allowed from the main package entry point.';
 const fixtureDirectory = fs.mkdtempSync( path.join( os.tmpdir(), 'allow-imports-only-from-main-package-entry-point-' ) );
-const exportedPackageDirectory = path.join( fixtureDirectory, 'node_modules/@ckeditor/ckeditor5-exported-package' );
 
-fs.mkdirSync( exportedPackageDirectory, { recursive: true } );
-fs.writeFileSync( path.join( exportedPackageDirectory, 'package.json' ), JSON.stringify( {
+createPackageJson( '@ckeditor/ckeditor5-exported-package', {
 	name: '@ckeditor/ckeditor5-exported-package',
 	exports: {
 		'./feature': {
@@ -26,7 +24,18 @@ fs.writeFileSync( path.join( exportedPackageDirectory, 'package.json' ), JSON.st
 			import: './dist/utils.js'
 		}
 	}
-}, null, '\t' ) );
+} );
+
+createPackageJson( '@ckeditor/ckeditor5-wildcard-package', {
+	name: '@ckeditor/ckeditor5-wildcard-package',
+	exports: {
+		'./*': './*'
+	}
+} );
+
+createPackageJson( '@ckeditor/ckeditor5-no-exports-package', {
+	name: '@ckeditor/ckeditor5-no-exports-package'
+} );
 
 const RuleTester = require( 'eslint' ).RuleTester;
 
@@ -49,33 +58,41 @@ ruleTester.run(
 				code: 'import { ExportedFeature } from \'@ckeditor/ckeditor5-exported-package/feature\';',
 				filename: path.join( fixtureDirectory, 'input.js' )
 			},
+			{
+				code: 'import { WildcardFeature } from \'@ckeditor/ckeditor5-wildcard-package/src/feature\';',
+				filename: path.join( fixtureDirectory, 'input.js' )
+			},
 			'import { Helper } from \'@ckeditor/ckeditor5-core/tests/_utils/helper.js\';',
 			'import { Helper } from \'@ckeditor/ckeditor5-core/tests/manual/_utils/helper.js\';',
 			'import { Helper } from \'@ckeditor/ckeditor5-core/tests/feature/_utils/helper.js\';',
 			'import { Helper } from \'@ckeditor/ckeditor5-core/tests/feature/_utils-tests/helper.js\';'
 		],
 		invalid: [
-			// Do not allow importing from the `src` folder.
+			// Do not allow importing from a package without the `exports` field.
 			{
-				code: 'import Table from "@ckeditor/ckeditor5-table/src/table";',
-				output: 'import { Table } from \'@ckeditor/ckeditor5-table\';',
+				code: 'import NoExportsFeature from "@ckeditor/ckeditor5-no-exports-package/src/feature";',
+				output: 'import { NoExportsFeature } from \'@ckeditor/ckeditor5-no-exports-package\';',
+				filename: path.join( fixtureDirectory, 'input.js' ),
 				errors: [ { message } ]
 			},
-			// Do not allow importing icons from the `theme` folder.
+			// Do not allow importing icons from a package without the `exports` field.
 			{
-				code: 'import icon from "@ckeditor/ckeditor5-table/theme/icons/icon.svg";',
-				output: 'import { icon } from \'@ckeditor/ckeditor5-table\';',
+				code: 'import icon from "@ckeditor/ckeditor5-no-exports-package/theme/icons/icon.svg";',
+				output: 'import { icon } from \'@ckeditor/ckeditor5-no-exports-package\';',
+				filename: path.join( fixtureDirectory, 'input.js' ),
 				errors: [ { message } ]
 			},
-			// Do not allow importing style sheets from the `theme` folder.
+			// Do not allow importing style sheets from a package without the `exports` field.
 			{
-				code: 'import styles from "@ckeditor/ckeditor5-table/theme/styles.css";',
-				output: 'import { styles } from \'@ckeditor/ckeditor5-table\';',
+				code: 'import styles from "@ckeditor/ckeditor5-no-exports-package/theme/styles.css";',
+				output: 'import { styles } from \'@ckeditor/ckeditor5-no-exports-package\';',
+				filename: path.join( fixtureDirectory, 'input.js' ),
 				errors: [ { message } ]
 			},
 			// Do not fix if there are both default and named imports.
 			{
-				code: 'import Foo, { Bar } from "@ckeditor/ckeditor5-core/src/core";',
+				code: 'import Foo, { Bar } from "@ckeditor/ckeditor5-no-exports-package/src/core";',
+				filename: path.join( fixtureDirectory, 'input.js' ),
 				errors: [ { message } ]
 			},
 			// Do not allow importing from package subpaths not listed in the `exports` field.
@@ -88,3 +105,10 @@ ruleTester.run(
 		]
 	}
 );
+
+function createPackageJson( packageName, packageJson ) {
+	const packageDirectory = path.join( fixtureDirectory, 'node_modules', packageName );
+
+	fs.mkdirSync( packageDirectory, { recursive: true } );
+	fs.writeFileSync( path.join( packageDirectory, 'package.json' ), JSON.stringify( packageJson, null, '\t' ) );
+}

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/allow-imports-only-from-main-package-entry-point.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/allow-imports-only-from-main-package-entry-point.js
@@ -5,7 +5,28 @@
 
 'use strict';
 
+const fs = require( 'node:fs' );
+const os = require( 'node:os' );
+const path = require( 'node:path' );
+
 const message = 'Importing from "@ckeditor/*" packages is only allowed from the main package entry point.';
+const fixtureDirectory = fs.mkdtempSync( path.join( os.tmpdir(), 'allow-imports-only-from-main-package-entry-point-' ) );
+const exportedPackageDirectory = path.join( fixtureDirectory, 'node_modules/@ckeditor/ckeditor5-exported-package' );
+
+fs.mkdirSync( exportedPackageDirectory, { recursive: true } );
+fs.writeFileSync( path.join( exportedPackageDirectory, 'package.json' ), JSON.stringify( {
+	name: '@ckeditor/ckeditor5-exported-package',
+	exports: {
+		'./feature': {
+			types: './dist/feature/index.d.ts',
+			import: './dist/feature.js'
+		},
+		'./utils': {
+			types: './dist/utils/index.d.ts',
+			import: './dist/utils.js'
+		}
+	}
+}, null, '\t' ) );
 
 const RuleTester = require( 'eslint' ).RuleTester;
 
@@ -24,6 +45,10 @@ ruleTester.run(
 			'import Foo from \'Foo\';',
 			'import Foo from \'ckeditor5-foo/bar/baz.js\';',
 			'import { Table } from \'@ckeditor/ckeditor5-table\';',
+			{
+				code: 'import { ExportedFeature } from \'@ckeditor/ckeditor5-exported-package/feature\';',
+				filename: path.join( fixtureDirectory, 'input.js' )
+			},
 			'import { Helper } from \'@ckeditor/ckeditor5-core/tests/_utils/helper.js\';',
 			'import { Helper } from \'@ckeditor/ckeditor5-core/tests/manual/_utils/helper.js\';',
 			'import { Helper } from \'@ckeditor/ckeditor5-core/tests/feature/_utils/helper.js\';',
@@ -51,6 +76,13 @@ ruleTester.run(
 			// Do not fix if there are both default and named imports.
 			{
 				code: 'import Foo, { Bar } from "@ckeditor/ckeditor5-core/src/core";',
+				errors: [ { message } ]
+			},
+			// Do not allow importing from package subpaths not listed in the `exports` field.
+			{
+				code: 'import ExportedFeature from "@ckeditor/ckeditor5-exported-package/dist/feature.js";',
+				output: 'import { ExportedFeature } from \'@ckeditor/ckeditor5-exported-package\';',
+				filename: path.join( fixtureDirectory, 'input.js' ),
 				errors: [ { message } ]
 			}
 		]


### PR DESCRIPTION
### 🚀 Summary

The `allow-imports-only-from-main-package-entry-point` ESLint rule now allows imports from explicitly exported package subpaths declared in `package.json`.

### 📌 Related issues

* See: https://github.com/ckeditor/ckeditor5-internal/issues/4544.

---

### 💡 Additional information

N/A
