### PR TITLE
Fix `require-file-extensions-in-imports` crashing on unresolvable export subpaths

### DIFF
--- a/.changelog/20260629140429_ck_20197_fix_require_file_extensions_crash.md
+++ b/.changelog/20260629140429_ck_20197_fix_require_file_extensions_crash.md
@@ -1,0 +1,9 @@
+---
+type: Fix
+scope:
+  - eslint-plugin-ckeditor5-rules
+closes:
+  - ckeditor/ckeditor5#20197
+---
+
+The `ckeditor5-rules/require-file-extensions-in-imports` rule no longer crashes when an import points to a subpath that is not registered in the target package's `exports` field. Such imports are now reported as a regular missing file extension error.

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/require-file-extensions-in-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/require-file-extensions-in-imports.js
@@ -198,5 +198,9 @@ function isExternalPackage( url ) {
 		return false;
 	}
 
-	return resolveExports( packageJson, url ).every( extname );
+	try {
+		return resolveExports( packageJson, url ).every( extname );
+	} catch {
+		return false;
+	}
 }

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/require-file-extensions-in-imports.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/require-file-extensions-in-imports.js
@@ -167,6 +167,12 @@ ruleTester.run( 'require-file-extensions-in-imports', require( '../../lib/rules/
 			errors: [
 				'Missing file extension in import/export "@ckeditor/ckeditor5-dev-utils/lib/index"'
 			]
+		},
+		{
+			code: 'export { Linter } from "eslint/lib/foo/bar";',
+			errors: [
+				'Missing file extension in import/export "eslint/lib/foo/bar"'
+			]
 		}
 	]
 } );


### PR DESCRIPTION
### 🚀 Summary

Fix `require-file-extensions-in-imports` crashing on unresolvable export subpaths.

---

### 📌 Related issues

* Closes ckeditor/ckeditor5#20197

---

### 💡 Additional information

N/A
