### PR TITLE
Remove the notify_ci_failure job from the CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,35 +79,6 @@ commands:
             echo export CKE5_COMMIT_SHA1=$CIRCLE_SHA1 >> $BASH_ENV
 
 jobs:
-  notify_ci_failure:
-    docker:
-      - image: cimg/node:22.12.0
-    parameters:
-      hideAuthor:
-        type: string
-        default: "false"
-    steps:
-      - checkout
-      - bootstrap_repository_command
-      - run:
-          # In the PRs that comes from forked repositories, we do not share secret variables.
-          # Hence, some of the scripts will not be executed.
-          name: 👤 Verify if the build was triggered by community - Check if the build should continue
-          command: |
-            #!/bin/bash
-
-            if [[ -z ${COVERALLS_REPO_TOKEN} ]];
-            then
-              circleci-agent step halt
-            fi
-      - run:
-          environment:
-            CKE5_SLACK_NOTIFY_HIDE_AUTHOR: << parameters.hideAuthor >>
-            CKE5_PIPELINE_NUMBER: << pipeline.number >>
-          name: Waiting for other jobs to finish and sending notification on failure
-          command: yarn ckeditor5-dev-ci-circle-workflow-notifier
-          no_output_timeout: 1h
-
   validate_and_tests:
     docker:
       - image: cimg/node:22.12.0
@@ -232,11 +203,6 @@ workflows:
             branches:
               only:
                 - master-v11
-      - notify_ci_failure:
-          filters:
-            branches:
-              only:
-                - master-v11
 
   release:
     when:
@@ -257,9 +223,3 @@ workflows:
         - equal: [ false, << pipeline.parameters.isRelease >> ]
     jobs:
       - validate_and_tests
-      - notify_ci_failure:
-          hideAuthor: "true"
-          filters:
-            branches:
-              only:
-                - master-v11


### PR DESCRIPTION
### 🚀 Summary

CI failure notifications for this repository are now sent by DevHub. DevHub listens to the CircleCI `workflow-completed` webhook and posts the failure message to Slack. The `notify_ci_failure` job that polled the workflow status is no longer needed, so this PR removes it from the CircleCI configuration.

---

### 📌 Related issues

* See https://github.com/cksource/ckeditor5-devhub/issues/424.

---

### 💡 Additional information

This is an internal-only change (CI tooling), so it does not need a changelog entry.
