### PR TITLE
Add `ckeditor5-rules/no-shadow-unsafe-dom-apis` rule

### DIFF
--- a/.changelog/20260720141421_ck_10990.md
+++ b/.changelog/20260720141421_ck_10990.md
@@ -1,0 +1,7 @@
+---
+type: Feature
+scope:
+  - eslint-plugin-ckeditor5-rules
+---
+
+Added the `ckeditor5-rules/no-shadow-unsafe-dom-apis` ESLint rule, which flags DOM APIs that do not work correctly inside a Shadow DOM (e.g. `document.activeElement`, `document.body.contains(...)`, global `getSelection()`, raw `.parentNode` traversal).

--- a/packages/eslint-plugin-ckeditor5-rules/lib/index.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/index.js
@@ -27,6 +27,7 @@ module.exports = {
 		'no-missing-var-function': require( './rules/no-missing-var-function' ),
 		'no-relative-imports': require( './rules/no-relative-imports' ),
 		'no-scoped-imports-within-package': require( './rules/no-scoped-imports-within-package' ),
+		'no-shadow-unsafe-dom-apis': require( './rules/no-shadow-unsafe-dom-apis.js' ),
 		'non-public-members-as-internal': require( './rules/non-public-members-as-internal' ),
 		'prevent-license-key-leak': require( './rules/prevent-license-key-leak' ),
 		'require-as-const-returns-in-methods': require( './rules/require-as-const-returns-in-methods' ),

--- a/packages/eslint-plugin-ckeditor5-rules/lib/index.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/index.js
@@ -27,7 +27,7 @@ module.exports = {
 		'no-missing-var-function': require( './rules/no-missing-var-function' ),
 		'no-relative-imports': require( './rules/no-relative-imports' ),
 		'no-scoped-imports-within-package': require( './rules/no-scoped-imports-within-package' ),
-		'no-shadow-unsafe-dom-apis': require( './rules/no-shadow-unsafe-dom-apis.js' ),
+		'no-shadow-unsafe-dom-apis': require( './rules/no-shadow-unsafe-dom-apis' ),
 		'non-public-members-as-internal': require( './rules/non-public-members-as-internal' ),
 		'prevent-license-key-leak': require( './rules/prevent-license-key-leak' ),
 		'require-as-const-returns-in-methods': require( './rules/require-as-const-returns-in-methods' ),

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
@@ -26,12 +26,15 @@ module.exports = {
 				'— `{{ path }}` ignores Shadow DOM.',
 			caretFromPoint: 'Call `{{ path }}(...)` with a `{ shadowRoots }` option, ' +
 				'otherwise it will not resolve carets inside Shadow DOM.',
+			caretRangeFromPointUnsupported: 'Native `{{ path }}(...)` does not accept a `{ shadowRoots }` option and ' +
+				'always ignores Shadow DOM, regardless of any argument passed. Use `caretPositionFromPoint()` from ' +
+				'the Shadow DOM utils instead.',
 			documentQuerySelector: 'Do not query `{{ path }}(...)` against the top-level document, query the ' +
 				'editor\'s own root instead — it finds nothing inside a shadow root.',
 			composedPath: 'Do not use `composedPath()` for root discovery, keep a held reference or use `getRootNode()`.',
 			documentListener: 'Do not attach a `{{ event }}` listener on `{{ path }}`, use a per-root ' +
 				'listener registry — it will not fire for events inside other shadow roots.',
-			bodyAppendChild: 'Do not append directly to `{{ path }}(...)`, use the shadow-aware body-collection root.'
+			bodyAppendChild: 'Do not append directly to `{{ path }}`, use the shadow-aware body-collection root.'
 		}
 	},
 	create( context ) {
@@ -209,15 +212,35 @@ function checkCallElementFromPoint( { node, context, path } ) {
 }
 
 /**
- * Flags `caretRangeFromPoint(...)` / `caretPositionFromPoint(...)` calls missing a `{ shadowRoots }`
- * option, without which they will not resolve carets inside Shadow DOM.
+ * Flags `caretRangeFromPoint(...)` / `caretPositionFromPoint(...)` calls that cannot resolve carets
+ * inside Shadow DOM. Native `Document.caretRangeFromPoint(...)` only accepts coordinates and silently
+ * ignores any extra argument, so it is unsafe on a document access path no matter what is passed;
+ * `caretPositionFromPoint(...)` and a bare, non-member call are only unsafe when missing a
+ * `{ shadowRoots }` option.
  *
- * document.caretRangeFromPoint( x, y ); // not allowed, missing { shadowRoots }
+ * document.caretRangeFromPoint( x, y, { shadowRoots } ); // not allowed, the option is a no-op here
  */
 function checkCallCaretFromPoint( { node, context, path } ) {
-	const isTargetCall = /(^|\.)(caretRangeFromPoint|caretPositionFromPoint)$/.test( path );
+	const match = path.match( /^(?:(.+)\.)?(caretRangeFromPoint|caretPositionFromPoint)$/ );
 
-	if ( !isTargetCall || hasShadowRootsOption( { args: node.arguments } ) ) {
+	if ( !match ) {
+		return;
+	}
+
+	const [ , prefix, methodName ] = match;
+	const isUnsupportedNativeCall = methodName === 'caretRangeFromPoint' && Boolean( prefix ) && isDocumentAccessPath( prefix );
+
+	if ( isUnsupportedNativeCall ) {
+		context.report( {
+			node,
+			messageId: 'caretRangeFromPointUnsupported',
+			data: { path }
+		} );
+
+		return;
+	}
+
+	if ( hasShadowRootsOption( { args: node.arguments } ) ) {
 		return;
 	}
 
@@ -321,7 +344,7 @@ function checkCallBodyAppendChild( { node, context, path } ) {
 	context.report( {
 		node,
 		messageId: 'bodyAppendChild',
-		data: { path }
+		data: { path: `${ match[ 1 ] }.body` }
 	} );
 }
 

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
@@ -138,10 +138,10 @@ function checkMemberParentTraversal( { node, context } ) {
  * Flags calls to `getSelection()` in any global or cross-root form. A bare `getSelection()` call is
  * only flagged when it resolves to the global one, not to a locally imported or declared helper.
  *
- * window.getSelection(); // not allowed
+ * global.window.getSelection(); // not allowed
  */
 function checkCallGetSelection( { node, context, path } ) {
-	const isGlobalCall = /^(window|document|global)\.getSelection$/.test( path );
+	const isGlobalCall = /^(global\.)?(window|document)\.getSelection$/.test( path ) || path === 'global.getSelection';
 	const isCrossRootCall = /\.(ownerDocument|defaultView)\.getSelection$/.test( path );
 	const isBareGlobalCall = path === 'getSelection' && !isLocallyDefinedReference( { node: node.callee, context } );
 
@@ -157,13 +157,19 @@ function checkCallGetSelection( { node, context, path } ) {
 }
 
 /**
- * Flags `.contains(...)` called on `document.body` or `*.ownerDocument`, which does not cross
- * Shadow DOM boundaries.
+ * Flags `.contains(...)` called on the top-level document body (`document.body`,
+ * `global.document.body`, or `*.ownerDocument.body`) or directly on `*.ownerDocument`, which does
+ * not cross Shadow DOM boundaries. A `.body.contains(...)` call on a non-document object is not
+ * restricted here, since `body` is a common, unrelated property name.
  *
  * document.body.contains( el ); // not allowed, use isConnected()
  */
 function checkCallContains( { node, context, path } ) {
-	if ( !/\.(body|ownerDocument)\.contains$/.test( path ) ) {
+	const isOwnerDocumentContains = /\.ownerDocument\.contains$/.test( path );
+	const bodyMatch = path.match( /^(.+)\.body\.contains$/ );
+	const isDocumentBodyContains = Boolean( bodyMatch ) && isDocumentAccessPath( bodyMatch[ 1 ] );
+
+	if ( !isOwnerDocumentContains && !isDocumentBodyContains ) {
 		return;
 	}
 

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
@@ -299,12 +299,15 @@ function checkCallDocumentElementLookup( { node, context, path } ) {
 }
 
 /**
- * Flags `composedPath()` used for root discovery.
+ * Flags `composedPath()` only when it's used for root discovery — indexed or destructured right away
+ * to pull out a single node. Keeping the result as an array and checking membership (`.includes(...)`,
+ * `.some(...)`, etc.) is the correct, shadow-DOM-safe way to test ancestry and is not restricted here.
  *
  * event.composedPath()[ 0 ]; // not allowed, use getRootNode()
+ * path.includes( contextElement ); // fine, not a root-discovery read
  */
 function checkCallComposedPath( { node, context, path } ) {
-	if ( !/(^|\.)composedPath$/.test( path ) ) {
+	if ( !/(^|\.)composedPath$/.test( path ) || !isImmediatelyIndexedOrDestructured( node ) ) {
 		return;
 	}
 
@@ -312,6 +315,30 @@ function checkCallComposedPath( { node, context, path } ) {
 		node,
 		messageId: 'composedPath'
 	} );
+}
+
+/**
+ * Checks whether a call expression's result is immediately indexed (`foo()[ 0 ]`) or array-destructured
+ * (`const [ x ] = foo();` / `[ x ] = foo();`), as opposed to kept as a whole array.
+ *
+ * isImmediatelyIndexedOrDestructured( node ); // node for `event.composedPath()[ 0 ]` -> true
+ */
+function isImmediatelyIndexedOrDestructured( node ) {
+	const parent = node.parent;
+
+	if ( parent.type === 'MemberExpression' && parent.object === node && parent.computed ) {
+		return true;
+	}
+
+	if ( parent.type === 'VariableDeclarator' && parent.init === node && parent.id.type === 'ArrayPattern' ) {
+		return true;
+	}
+
+	if ( parent.type === 'AssignmentExpression' && parent.right === node && parent.left.type === 'ArrayPattern' ) {
+		return true;
+	}
+
+	return false;
 }
 
 /**

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
@@ -299,7 +299,7 @@ function checkCallDocumentListener( { node, context, path } ) {
 	context.report( {
 		node,
 		messageId: 'documentListener',
-		data: { event: eventName, path }
+		data: { event: eventName, path: match[ 1 ] }
 	} );
 }
 

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
@@ -57,7 +57,7 @@ module.exports = {
 
 		return {
 			MemberExpression( node ) {
-				if ( node.computed ) {
+				if ( node.computed || node.property.type !== 'Identifier' ) {
 					return;
 				}
 
@@ -372,7 +372,9 @@ function getAccessPath( { node } ) {
 	}
 
 	if ( unwrapped.type === 'MemberExpression' ) {
-		const propertyName = unwrapped.computed ? '*' : unwrapped.property.name;
+		const propertyName = !unwrapped.computed && unwrapped.property.type === 'Identifier' ?
+			unwrapped.property.name :
+			'*';
 
 		return `${ getAccessPath( { node: unwrapped.object } ) }.${ propertyName }`;
 	}

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
@@ -20,7 +20,7 @@ module.exports = {
 			parentTraversal: 'Do not traverse `.{{ property }}` directly, use `getParentOrHostElement()` ' +
 				'to cross Shadow DOM boundaries correctly.',
 			getSelection: 'Do not call `{{ path }}(...)` directly, use `getSelection()` from the Shadow DOM utils.',
-			contains: 'Do not use `{{ path }}(...)`, use `isConnected()` instead — ' +
+			contains: 'Do not use `{{ path }}(...)`, use `isConnected` instead — ' +
 				'`contains()` does not cross Shadow DOM boundaries.',
 			elementFromPoint: 'Do not use `{{ path }}(...)` directly, resolve the point via the element\'s own root ' +
 				'— `{{ path }}` ignores Shadow DOM.',
@@ -162,7 +162,7 @@ function checkCallGetSelection( { node, context, path } ) {
  * not cross Shadow DOM boundaries. A `.body.contains(...)` call on a non-document object is not
  * restricted here, since `body` is a common, unrelated property name.
  *
- * document.body.contains( el ); // not allowed, use isConnected()
+ * document.body.contains( el ); // not allowed, use isConnected
  */
 function checkCallContains( { node, context, path } ) {
 	const isOwnerDocumentContains = /\.ownerDocument\.contains$/.test( path );

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
@@ -26,12 +26,12 @@ module.exports = {
 				'— `{{ path }}` ignores Shadow DOM.',
 			caretFromPoint: 'Call `{{ path }}(...)` with a `{ shadowRoots }` option, ' +
 				'otherwise it will not resolve carets inside Shadow DOM.',
-			globalQuerySelector: 'Do not query `{{ path }}(...)` against the global `document`, query the editor\'s ' +
-				'own root instead — it finds nothing inside a shadow root.',
+			documentQuerySelector: 'Do not query `{{ path }}(...)` against the top-level document, query the ' +
+				'editor\'s own root instead — it finds nothing inside a shadow root.',
 			composedPath: 'Do not use `composedPath()` for root discovery, keep a held reference or use `getRootNode()`.',
 			globalDocumentListener: 'Do not attach a global `{{ event }}` listener on `document`, use a per-root ' +
 				'listener registry — it will not fire for events inside other shadow roots.',
-			bodyAppendChild: 'Do not append directly to `document.body`, use the shadow-aware body-collection root.'
+			bodyAppendChild: 'Do not append directly to `{{ path }}(...)`, use the shadow-aware body-collection root.'
 		}
 	},
 	create( context ) {
@@ -46,7 +46,7 @@ module.exports = {
 			checkCallContains,
 			checkCallElementFromPoint,
 			checkCallCaretFromPoint,
-			checkCallGlobalQuerySelector,
+			checkCallDocumentQuerySelector,
 			checkCallComposedPath,
 			checkCallGlobalDocumentListener,
 			checkCallBodyAppendChild
@@ -76,8 +76,8 @@ module.exports = {
 };
 
 /**
- * Flags reading `document.activeElement` or `*.ownerDocument.activeElement`, which is not tracked
- * across Shadow DOM boundaries.
+ * Flags reading `document.activeElement`, `global.document.activeElement`, or
+ * `*.ownerDocument.activeElement`, which is not tracked across Shadow DOM boundaries.
  *
  * document.activeElement; // not allowed, use getActiveElement()
  */
@@ -88,7 +88,7 @@ function checkMemberActiveElement( { node, context } ) {
 
 	const objectPath = getAccessPath( { node: node.object } );
 
-	if ( !/(^document$|\.ownerDocument$)/.test( objectPath ) ) {
+	if ( !isDocumentAccessPath( objectPath ) ) {
 		return;
 	}
 
@@ -135,16 +135,17 @@ function checkMemberParentTraversal( { node, context } ) {
 }
 
 /**
- * Flags calls to `getSelection()` in any global or cross-root form.
+ * Flags calls to `getSelection()` in any global or cross-root form. A bare `getSelection()` call is
+ * only flagged when it resolves to the global one, not to a locally imported or declared helper.
  *
  * window.getSelection(); // not allowed
  */
 function checkCallGetSelection( { node, context, path } ) {
-	const isBareCall = path === 'getSelection';
 	const isGlobalCall = /^(window|document|global)\.getSelection$/.test( path );
 	const isCrossRootCall = /\.(ownerDocument|defaultView)\.getSelection$/.test( path );
+	const isBareGlobalCall = path === 'getSelection' && !isLocallyDefinedReference( { node: node.callee, context } );
 
-	if ( !isBareCall && !isGlobalCall && !isCrossRootCall ) {
+	if ( !isBareGlobalCall && !isGlobalCall && !isCrossRootCall ) {
 		return;
 	}
 
@@ -174,12 +175,15 @@ function checkCallContains( { node, context, path } ) {
 }
 
 /**
- * Flags `document.elementFromPoint(...)` / `document.elementsFromPoint(...)`, which ignore Shadow DOM.
+ * Flags `document.elementFromPoint(...)` / `elementsFromPoint(...)` called on the top-level document
+ * (`document`, `global.document`, or `*.ownerDocument`), which ignores Shadow DOM.
  *
  * document.elementFromPoint( x, y ); // not allowed
  */
 function checkCallElementFromPoint( { node, context, path } ) {
-	if ( !/^document\.(elementFromPoint|elementsFromPoint)$/.test( path ) ) {
+	const match = path.match( /^(.+)\.(elementFromPoint|elementsFromPoint)$/ );
+
+	if ( !match || !isDocumentAccessPath( match[ 1 ] ) ) {
 		return;
 	}
 
@@ -223,19 +227,22 @@ function checkCallCaretFromPoint( { node, context, path } ) {
 }
 
 /**
- * Flags `document.querySelector(...)` / `querySelectorAll(...)` / `getElementById(...)` called
- * against the global `document`, which finds nothing inside a shadow root.
+ * Flags `querySelector(...)` / `querySelectorAll(...)` / `getElementById(...)` called on the
+ * top-level document (`document`, `global.document`, or `*.ownerDocument`), which finds nothing
+ * inside a shadow root.
  *
  * document.querySelector( '.foo' ); // not allowed
  */
-function checkCallGlobalQuerySelector( { node, context, path } ) {
-	if ( !/^document\.(querySelector|querySelectorAll|getElementById)$/.test( path ) ) {
+function checkCallDocumentQuerySelector( { node, context, path } ) {
+	const match = path.match( /^(.+)\.(querySelector|querySelectorAll|getElementById)$/ );
+
+	if ( !match || !isDocumentAccessPath( match[ 1 ] ) ) {
 		return;
 	}
 
 	context.report( {
 		node,
-		messageId: 'globalQuerySelector',
+		messageId: 'documentQuerySelector',
 		data: { path }
 	} );
 }
@@ -282,18 +289,22 @@ function checkCallGlobalDocumentListener( { node, context, path } ) {
 }
 
 /**
- * Flags appending directly to `document.body`.
+ * Flags appending directly to the top-level document body (`document.body`, `global.document.body`,
+ * or `*.ownerDocument.body`).
  *
  * document.body.appendChild( el ); // not allowed
  */
 function checkCallBodyAppendChild( { node, context, path } ) {
-	if ( path !== 'document.body.appendChild' ) {
+	const match = path.match( /^(.+)\.body\.appendChild$/ );
+
+	if ( !match || !isDocumentAccessPath( match[ 1 ] ) ) {
 		return;
 	}
 
 	context.report( {
 		node,
-		messageId: 'bodyAppendChild'
+		messageId: 'bodyAppendChild',
+		data: { path }
 	} );
 }
 
@@ -327,4 +338,38 @@ function getAccessPath( { node } ) {
 	}
 
 	return '*';
+}
+
+/**
+ * Checks whether a path refers to the top-level document: `document`, `global.document`, or any
+ * `*.ownerDocument` access.
+ *
+ * isDocumentAccessPath( 'global.document' ); // -> true
+ */
+function isDocumentAccessPath( path ) {
+	return /^(global\.)?document$/.test( path ) || /\.ownerDocument$/.test( path );
+}
+
+/**
+ * Checks whether an identifier reference resolves to a variable declared or imported in the source
+ * (as opposed to an unresolved, implicitly global one).
+ *
+ * import { getSelection } from './shadow-dom-utils.js'; // -> resolves locally, not global
+ */
+function isLocallyDefinedReference( { node, context } ) {
+	const sourceCode = context.sourceCode || context.getSourceCode();
+
+	let scope = sourceCode.getScope ? sourceCode.getScope( node ) : context.getScope();
+
+	while ( scope ) {
+		const reference = scope.references.find( ref => ref.identifier === node );
+
+		if ( reference ) {
+			return Boolean( reference.resolved && reference.resolved.defs.length > 0 );
+		}
+
+		scope = scope.upper;
+	}
+
+	return false;
 }

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
@@ -340,9 +340,9 @@ function checkCallDocumentTreeWalker( { node, context, path } ) {
 }
 
 /**
- * Flags `mouseenter` / `mouseleave` / `scroll` listeners attached to the top-level document
- * (`document`, `global.document`, or `*.ownerDocument`), which will not fire for events inside
- * other shadow roots.
+ * Flags `mouseenter` / `mouseleave` / `pointerenter` / `pointerleave` / `scroll` listeners attached
+ * to the top-level document (`document`, `global.document`, or `*.ownerDocument`), which will not
+ * fire for events inside other shadow roots.
  *
  * document.addEventListener( 'scroll', listener ); // not allowed
  */
@@ -356,7 +356,7 @@ function checkCallDocumentListener( { node, context, path } ) {
 	const eventArg = unwrapExpression( node.arguments[ 0 ] );
 	const eventName = eventArg && eventArg.type === 'Literal' ? eventArg.value : null;
 
-	if ( ![ 'mouseenter', 'mouseleave', 'scroll' ].includes( eventName ) ) {
+	if ( ![ 'mouseenter', 'mouseleave', 'pointerenter', 'pointerleave', 'scroll' ].includes( eventName ) ) {
 		return;
 	}
 
@@ -435,16 +435,20 @@ function isTypeScriptWrapperExpression( node ) {
 }
 
 /**
- * Strips TypeScript wrapper nodes (`x as Document`, `x!`, `<Document>x`, `x satisfies Document`) and
- * `ChainExpression` wrappers (parenthesized optional chains, e.g. `(x?.y)`) down to the expression
- * underneath, since neither changes what is actually being accessed or called.
+ * Strips TypeScript wrapper nodes (`x as Document`, `x!`, `<Document>x`, `x satisfies Document`),
+ * `ChainExpression` wrappers (parenthesized optional chains, e.g. `(x?.y)`), and
+ * `ParenthesizedExpression` wrappers (grouping parens preserved by some parsers, e.g. `(x)`) down to
+ * the expression underneath, since none of them change what is actually being accessed or called.
  *
  * unwrapExpression( node ); // node for `document!` -> node for `document`
  */
 function unwrapExpression( node ) {
 	let current = node;
 
-	while ( current && ( isTypeScriptWrapperExpression( current ) || current.type === 'ChainExpression' ) ) {
+	while (
+		current &&
+		( isTypeScriptWrapperExpression( current ) || [ 'ChainExpression', 'ParenthesizedExpression' ].includes( current.type ) )
+	) {
 		current = current.expression;
 	}
 

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
@@ -261,10 +261,11 @@ function checkCallCaretFromPoint( { node, context, path } ) {
 /**
  * Flags `querySelector(...)` / `querySelectorAll(...)` / `getElementById(...)` /
  * `getElementsByTagName(...)` / `getElementsByClassName(...)` / `getElementsByName(...)` called on
- * the top-level document (`document`, `global.document`, or `*.ownerDocument`), which finds nothing
+ * the top-level document (`document`, `global.document`, or `*.ownerDocument`) or on its body
+ * (`document.body`, `global.document.body`, or `*.ownerDocument.body`), which finds nothing
  * inside a shadow root.
  *
- * document.querySelector( '.foo' ); // not allowed
+ * document.body.querySelector( '.foo' ); // not allowed
  */
 function checkCallDocumentElementLookup( { node, context, path } ) {
 	const methods = [
@@ -278,7 +279,15 @@ function checkCallDocumentElementLookup( { node, context, path } ) {
 
 	const match = path.match( new RegExp( `^(.+)\\.(${ methods.join( '|' ) })$` ) );
 
-	if ( !match || !isDocumentAccessPath( match[ 1 ] ) ) {
+	if ( !match ) {
+		return;
+	}
+
+	const bodyMatch = match[ 1 ].match( /^(.+)\.body$/ );
+	const isDocumentQuery = isDocumentAccessPath( match[ 1 ] );
+	const isDocumentBodyQuery = Boolean( bodyMatch ) && isDocumentAccessPath( bodyMatch[ 1 ] );
+
+	if ( !isDocumentQuery && !isDocumentBodyQuery ) {
 		return;
 	}
 

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
@@ -1,0 +1,330 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+module.exports = {
+	meta: {
+		type: 'problem',
+		docs: {
+			description: 'Disallow the use of utilities that cannot be used within the Shadow DOM',
+			category: 'CKEditor5'
+		},
+		messages: {
+			activeElement: 'Do not read `{{ path }}.activeElement` directly, use `getActiveElement()` — ' +
+				'it is not tracked across Shadow DOM boundaries.',
+			shadowRootDiscovery: 'Do not use `.shadowRoot` for root discovery at read time. ' +
+				'Keep a held reference or use `getRootNode()`.',
+			parentTraversal: 'Do not traverse `.{{ property }}` directly, use `getParentOrHostElement()` ' +
+				'to cross Shadow DOM boundaries correctly.',
+			getSelection: 'Do not call `{{ path }}(...)` directly, use `getSelection()` from the Shadow DOM utils.',
+			contains: 'Do not use `{{ path }}(...)`, use `isConnected()` instead — ' +
+				'`contains()` does not cross Shadow DOM boundaries.',
+			elementFromPoint: 'Do not use `{{ path }}(...)` directly, resolve the point via the element\'s own root ' +
+				'— `{{ path }}` ignores Shadow DOM.',
+			caretFromPoint: 'Call `{{ path }}(...)` with a `{ shadowRoots }` option, ' +
+				'otherwise it will not resolve carets inside Shadow DOM.',
+			globalQuerySelector: 'Do not query `{{ path }}(...)` against the global `document`, query the editor\'s ' +
+				'own root instead — it finds nothing inside a shadow root.',
+			composedPath: 'Do not use `composedPath()` for root discovery, keep a held reference or use `getRootNode()`.',
+			globalDocumentListener: 'Do not attach a global `{{ event }}` listener on `document`, use a per-root ' +
+				'listener registry — it will not fire for events inside other shadow roots.',
+			bodyAppendChild: 'Do not append directly to `document.body`, use the shadow-aware body-collection root.'
+		}
+	},
+	create( context ) {
+		const memberExpressionChecks = [
+			checkMemberActiveElement,
+			checkMemberShadowRootDiscovery,
+			checkMemberParentTraversal
+		];
+
+		const callExpressionChecks = [
+			checkCallGetSelection,
+			checkCallContains,
+			checkCallElementFromPoint,
+			checkCallCaretFromPoint,
+			checkCallGlobalQuerySelector,
+			checkCallComposedPath,
+			checkCallGlobalDocumentListener,
+			checkCallBodyAppendChild
+		];
+
+		return {
+			MemberExpression( node ) {
+				if ( node.computed ) {
+					return;
+				}
+
+				const args = { node, context };
+
+				for ( const check of memberExpressionChecks ) {
+					check( args );
+				}
+			},
+			CallExpression( node ) {
+				const args = { node, context, path: getAccessPath( { node: node.callee } ) };
+
+				for ( const check of callExpressionChecks ) {
+					check( args );
+				}
+			}
+		};
+	}
+};
+
+/**
+ * Flags reading `document.activeElement` or `*.ownerDocument.activeElement`, which is not tracked
+ * across Shadow DOM boundaries.
+ *
+ * document.activeElement; // not allowed, use getActiveElement()
+ */
+function checkMemberActiveElement( { node, context } ) {
+	if ( node.property.name !== 'activeElement' ) {
+		return;
+	}
+
+	const objectPath = getAccessPath( { node: node.object } );
+
+	if ( !/(^document$|\.ownerDocument$)/.test( objectPath ) ) {
+		return;
+	}
+
+	context.report( {
+		node,
+		messageId: 'activeElement',
+		data: { path: objectPath }
+	} );
+}
+
+/**
+ * Flags reading `.shadowRoot` for root discovery at read time.
+ *
+ * el.shadowRoot; // not allowed, use getRootNode()
+ */
+function checkMemberShadowRootDiscovery( { node, context } ) {
+	if ( node.property.name !== 'shadowRoot' ) {
+		return;
+	}
+
+	context.report( {
+		node,
+		messageId: 'shadowRootDiscovery'
+	} );
+}
+
+/**
+ * Flags raw `.parentNode` / `.parentElement` traversal, which does not cross Shadow DOM boundaries.
+ *
+ * el.parentNode; // not allowed, use getParentOrHostElement()
+ */
+function checkMemberParentTraversal( { node, context } ) {
+	const propertyName = node.property.name;
+
+	if ( propertyName !== 'parentNode' && propertyName !== 'parentElement' ) {
+		return;
+	}
+
+	context.report( {
+		node,
+		messageId: 'parentTraversal',
+		data: { property: propertyName }
+	} );
+}
+
+/**
+ * Flags calls to `getSelection()` in any global or cross-root form.
+ *
+ * window.getSelection(); // not allowed
+ */
+function checkCallGetSelection( { node, context, path } ) {
+	const isBareCall = path === 'getSelection';
+	const isGlobalCall = /^(window|document|global)\.getSelection$/.test( path );
+	const isCrossRootCall = /\.(ownerDocument|defaultView)\.getSelection$/.test( path );
+
+	if ( !isBareCall && !isGlobalCall && !isCrossRootCall ) {
+		return;
+	}
+
+	context.report( {
+		node,
+		messageId: 'getSelection',
+		data: { path }
+	} );
+}
+
+/**
+ * Flags `.contains(...)` called on `document.body` or `*.ownerDocument`, which does not cross
+ * Shadow DOM boundaries.
+ *
+ * document.body.contains( el ); // not allowed, use isConnected()
+ */
+function checkCallContains( { node, context, path } ) {
+	if ( !/\.(body|ownerDocument)\.contains$/.test( path ) ) {
+		return;
+	}
+
+	context.report( {
+		node,
+		messageId: 'contains',
+		data: { path }
+	} );
+}
+
+/**
+ * Flags `document.elementFromPoint(...)` / `document.elementsFromPoint(...)`, which ignore Shadow DOM.
+ *
+ * document.elementFromPoint( x, y ); // not allowed
+ */
+function checkCallElementFromPoint( { node, context, path } ) {
+	if ( !/^document\.(elementFromPoint|elementsFromPoint)$/.test( path ) ) {
+		return;
+	}
+
+	context.report( {
+		node,
+		messageId: 'elementFromPoint',
+		data: { path }
+	} );
+}
+
+/**
+ * Flags `caretRangeFromPoint(...)` / `caretPositionFromPoint(...)` calls missing a `{ shadowRoots }`
+ * option, without which they will not resolve carets inside Shadow DOM.
+ *
+ * document.caretRangeFromPoint( x, y ); // not allowed, missing { shadowRoots }
+ */
+function checkCallCaretFromPoint( { node, context, path } ) {
+	const isTargetCall = /(^|\.)(caretRangeFromPoint|caretPositionFromPoint)$/.test( path );
+
+	if ( !isTargetCall || hasShadowRootsOption( { args: node.arguments } ) ) {
+		return;
+	}
+
+	context.report( {
+		node,
+		messageId: 'caretFromPoint',
+		data: { path }
+	} );
+
+	function hasShadowRootsOption( { args } ) {
+		const lastArg = args[ args.length - 1 ];
+
+		return Boolean(
+			lastArg &&
+			lastArg.type === 'ObjectExpression' &&
+			lastArg.properties.some( property =>
+				property.key && ( property.key.name === 'shadowRoots' || property.key.value === 'shadowRoots' )
+			)
+		);
+	}
+}
+
+/**
+ * Flags `document.querySelector(...)` / `querySelectorAll(...)` / `getElementById(...)` called
+ * against the global `document`, which finds nothing inside a shadow root.
+ *
+ * document.querySelector( '.foo' ); // not allowed
+ */
+function checkCallGlobalQuerySelector( { node, context, path } ) {
+	if ( !/^document\.(querySelector|querySelectorAll|getElementById)$/.test( path ) ) {
+		return;
+	}
+
+	context.report( {
+		node,
+		messageId: 'globalQuerySelector',
+		data: { path }
+	} );
+}
+
+/**
+ * Flags `composedPath()` used for root discovery.
+ *
+ * event.composedPath()[ 0 ]; // not allowed, use getRootNode()
+ */
+function checkCallComposedPath( { node, context, path } ) {
+	if ( !/(^|\.)composedPath$/.test( path ) ) {
+		return;
+	}
+
+	context.report( {
+		node,
+		messageId: 'composedPath'
+	} );
+}
+
+/**
+ * Flags global `mouseenter` / `mouseleave` / `scroll` listeners attached to `document`, which will
+ * not fire for events inside other shadow roots.
+ *
+ * document.addEventListener( 'scroll', listener ); // not allowed
+ */
+function checkCallGlobalDocumentListener( { node, context, path } ) {
+	if ( !/^(global\.document|document)\.(addEventListener|removeEventListener)$/.test( path ) ) {
+		return;
+	}
+
+	const eventArg = node.arguments[ 0 ];
+	const eventName = eventArg && eventArg.type === 'Literal' ? eventArg.value : null;
+
+	if ( ![ 'mouseenter', 'mouseleave', 'scroll' ].includes( eventName ) ) {
+		return;
+	}
+
+	context.report( {
+		node,
+		messageId: 'globalDocumentListener',
+		data: { event: eventName }
+	} );
+}
+
+/**
+ * Flags appending directly to `document.body`.
+ *
+ * document.body.appendChild( el ); // not allowed
+ */
+function checkCallBodyAppendChild( { node, context, path } ) {
+	if ( path !== 'document.body.appendChild' ) {
+		return;
+	}
+
+	context.report( {
+		node,
+		messageId: 'bodyAppendChild'
+	} );
+}
+
+/**
+ * Builds a dotted string representation of a member/call path, collapsing computed and other
+ * non-trivial segments to `*` so checks can rely on plain regexes.
+ *
+ * el.ownerDocument.defaultView.getSelection() -> 'el.ownerDocument.defaultView.getSelection()'
+ */
+function getAccessPath( { node } ) {
+	if ( !node ) {
+		return '';
+	}
+
+	if ( node.type === 'Identifier' ) {
+		return node.name;
+	}
+
+	if ( node.type === 'ThisExpression' ) {
+		return 'this';
+	}
+
+	if ( node.type === 'MemberExpression' ) {
+		const propertyName = node.computed ? '*' : node.property.name;
+
+		return `${ getAccessPath( { node: node.object } ) }.${ propertyName }`;
+	}
+
+	if ( node.type === 'CallExpression' ) {
+		return `${ getAccessPath( { node: node.callee } ) }()`;
+	}
+
+	return '*';
+}

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
@@ -20,7 +20,7 @@ module.exports = {
 			parentTraversal: 'Do not traverse `.{{ property }}` directly, use `getParentOrHostElement()` ' +
 				'to cross Shadow DOM boundaries correctly.',
 			getSelection: 'Do not call `{{ path }}(...)` directly, use `getSelection()` from the Shadow DOM utils.',
-			contains: 'Do not use `{{ path }}(...)`, use `isConnected` instead — ' +
+			contains: 'Do not use `{{ path }}(...)`, use `isConnected()` instead — ' +
 				'`contains()` does not cross Shadow DOM boundaries.',
 			elementFromPoint: 'Do not use `{{ path }}(...)` directly, resolve the point via the element\'s own root ' +
 				'— `{{ path }}` ignores Shadow DOM.',
@@ -29,7 +29,7 @@ module.exports = {
 			documentQuerySelector: 'Do not query `{{ path }}(...)` against the top-level document, query the ' +
 				'editor\'s own root instead — it finds nothing inside a shadow root.',
 			composedPath: 'Do not use `composedPath()` for root discovery, keep a held reference or use `getRootNode()`.',
-			globalDocumentListener: 'Do not attach a global `{{ event }}` listener on `document`, use a per-root ' +
+			documentListener: 'Do not attach a `{{ event }}` listener on `{{ path }}`, use a per-root ' +
 				'listener registry — it will not fire for events inside other shadow roots.',
 			bodyAppendChild: 'Do not append directly to `{{ path }}(...)`, use the shadow-aware body-collection root.'
 		}
@@ -48,7 +48,7 @@ module.exports = {
 			checkCallCaretFromPoint,
 			checkCallDocumentQuerySelector,
 			checkCallComposedPath,
-			checkCallGlobalDocumentListener,
+			checkCallDocumentListener,
 			checkCallBodyAppendChild
 		];
 
@@ -157,19 +157,25 @@ function checkCallGetSelection( { node, context, path } ) {
 }
 
 /**
- * Flags `.contains(...)` called on the top-level document body (`document.body`,
- * `global.document.body`, or `*.ownerDocument.body`) or directly on `*.ownerDocument`, which does
- * not cross Shadow DOM boundaries. A `.body.contains(...)` call on a non-document object is not
- * restricted here, since `body` is a common, unrelated property name.
+ * Flags `.contains(...)` called directly on the top-level document (`document`, `global.document`,
+ * or `*.ownerDocument`) or on its body (`document.body`, `global.document.body`, or
+ * `*.ownerDocument.body`), which does not cross Shadow DOM boundaries. A `.body.contains(...)` call
+ * on a non-document object is not restricted here, since `body` is a common, unrelated property name.
  *
- * document.body.contains( el ); // not allowed, use isConnected
+ * document.contains( el ); // not allowed, use isConnected()
  */
 function checkCallContains( { node, context, path } ) {
-	const isOwnerDocumentContains = /\.ownerDocument\.contains$/.test( path );
-	const bodyMatch = path.match( /^(.+)\.body\.contains$/ );
+	const match = path.match( /^(.+)\.contains$/ );
+
+	if ( !match ) {
+		return;
+	}
+
+	const bodyMatch = match[ 1 ].match( /^(.+)\.body$/ );
+	const isDocumentContains = isDocumentAccessPath( match[ 1 ] );
 	const isDocumentBodyContains = Boolean( bodyMatch ) && isDocumentAccessPath( bodyMatch[ 1 ] );
 
-	if ( !isOwnerDocumentContains && !isDocumentBodyContains ) {
+	if ( !isDocumentContains && !isDocumentBodyContains ) {
 		return;
 	}
 
@@ -270,13 +276,16 @@ function checkCallComposedPath( { node, context, path } ) {
 }
 
 /**
- * Flags global `mouseenter` / `mouseleave` / `scroll` listeners attached to `document`, which will
- * not fire for events inside other shadow roots.
+ * Flags `mouseenter` / `mouseleave` / `scroll` listeners attached to the top-level document
+ * (`document`, `global.document`, or `*.ownerDocument`), which will not fire for events inside
+ * other shadow roots.
  *
  * document.addEventListener( 'scroll', listener ); // not allowed
  */
-function checkCallGlobalDocumentListener( { node, context, path } ) {
-	if ( !/^(global\.document|document)\.(addEventListener|removeEventListener)$/.test( path ) ) {
+function checkCallDocumentListener( { node, context, path } ) {
+	const match = path.match( /^(.+)\.(addEventListener|removeEventListener)$/ );
+
+	if ( !match || !isDocumentAccessPath( match[ 1 ] ) ) {
 		return;
 	}
 
@@ -289,8 +298,8 @@ function checkCallGlobalDocumentListener( { node, context, path } ) {
 
 	context.report( {
 		node,
-		messageId: 'globalDocumentListener',
-		data: { event: eventName }
+		messageId: 'documentListener',
+		data: { event: eventName, path }
 	} );
 }
 

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
@@ -28,13 +28,15 @@ module.exports = {
 				'otherwise it will not resolve carets inside Shadow DOM.',
 			caretRangeFromPointUnsupported: 'Native `{{ path }}(...)` does not accept a `{ shadowRoots }` option and ' +
 				'always ignores Shadow DOM, regardless of any argument passed.',
-			documentQuerySelector: 'Do not query `{{ path }}(...)` against the top-level document, query the ' +
+			documentElementLookup: 'Do not query `{{ path }}(...)` against the top-level document, query the ' +
 				'editor\'s own root instead — it finds nothing inside a shadow root.',
 			composedPath: 'Do not use `composedPath()` for root discovery, keep a held reference or use ' +
 				'`getRootNode()` instead.',
 			documentListener: 'Do not attach a `{{ event }}` listener on `{{ path }}` — ' +
 				'it will not fire for events inside other shadow roots.',
-			bodyAppendChild: 'Do not append directly to `{{ path }}` — it does not account for Shadow DOM boundaries.'
+			bodyAppendChild: 'Do not append directly to `{{ path }}` — it does not account for Shadow DOM boundaries.',
+			documentTreeWalker: 'Do not call `{{ path }}(...)` rooted at `{{ root }}` — ' +
+				'it will not traverse into descendant shadow roots.'
 		}
 	},
 	create( context ) {
@@ -49,10 +51,11 @@ module.exports = {
 			checkCallContains,
 			checkCallElementFromPoint,
 			checkCallCaretFromPoint,
-			checkCallDocumentQuerySelector,
+			checkCallDocumentElementLookup,
 			checkCallComposedPath,
 			checkCallDocumentListener,
-			checkCallBodyAppendChild
+			checkCallBodyAppendChild,
+			checkCallDocumentTreeWalker
 		];
 
 		return {
@@ -172,15 +175,7 @@ function checkCallGetSelection( { node, context, path } ) {
 function checkCallContains( { node, context, path } ) {
 	const match = path.match( /^(.+)\.contains$/ );
 
-	if ( !match ) {
-		return;
-	}
-
-	const bodyMatch = match[ 1 ].match( /^(.+)\.body$/ );
-	const isDocumentContains = isDocumentAccessPath( match[ 1 ] );
-	const isDocumentBodyContains = Boolean( bodyMatch ) && isDocumentAccessPath( bodyMatch[ 1 ] );
-
-	if ( !isDocumentContains && !isDocumentBodyContains ) {
+	if ( !match || ( !isDocumentAccessPath( match[ 1 ] ) && !isDocumentBodyAccessPath( match[ 1 ] ) ) ) {
 		return;
 	}
 
@@ -264,14 +259,24 @@ function checkCallCaretFromPoint( { node, context, path } ) {
 }
 
 /**
- * Flags `querySelector(...)` / `querySelectorAll(...)` / `getElementById(...)` called on the
- * top-level document (`document`, `global.document`, or `*.ownerDocument`), which finds nothing
+ * Flags `querySelector(...)` / `querySelectorAll(...)` / `getElementById(...)` /
+ * `getElementsByTagName(...)` / `getElementsByClassName(...)` / `getElementsByName(...)` called on
+ * the top-level document (`document`, `global.document`, or `*.ownerDocument`), which finds nothing
  * inside a shadow root.
  *
  * document.querySelector( '.foo' ); // not allowed
  */
-function checkCallDocumentQuerySelector( { node, context, path } ) {
-	const match = path.match( /^(.+)\.(querySelector|querySelectorAll|getElementById)$/ );
+function checkCallDocumentElementLookup( { node, context, path } ) {
+	const methods = [
+		'querySelector',
+		'querySelectorAll',
+		'getElementById',
+		'getElementsByTagName',
+		'getElementsByClassName',
+		'getElementsByName'
+	];
+
+	const match = path.match( new RegExp( `^(.+)\\.(${ methods.join( '|' ) })$` ) );
 
 	if ( !match || !isDocumentAccessPath( match[ 1 ] ) ) {
 		return;
@@ -279,7 +284,7 @@ function checkCallDocumentQuerySelector( { node, context, path } ) {
 
 	context.report( {
 		node,
-		messageId: 'documentQuerySelector',
+		messageId: 'documentElementLookup',
 		data: { path }
 	} );
 }
@@ -297,6 +302,31 @@ function checkCallComposedPath( { node, context, path } ) {
 	context.report( {
 		node,
 		messageId: 'composedPath'
+	} );
+}
+
+/**
+ * Flags `createTreeWalker(...)` / `createNodeIterator(...)` rooted at the top-level document or its
+ * body (`document`, `global.document`, `document.body`, `global.document.body`, or
+ * `*.ownerDocument[.body]`), since neither traverses into descendant shadow roots.
+ *
+ * document.createTreeWalker( document.body, NodeFilter.SHOW_ELEMENT ); // not allowed
+ */
+function checkCallDocumentTreeWalker( { node, context, path } ) {
+	if ( !/(^|\.)(createTreeWalker|createNodeIterator)$/.test( path ) ) {
+		return;
+	}
+
+	const rootPath = getAccessPath( { node: node.arguments[ 0 ] } );
+
+	if ( !isDocumentAccessPath( rootPath ) && !isDocumentBodyAccessPath( rootPath ) ) {
+		return;
+	}
+
+	context.report( {
+		node,
+		messageId: 'documentTreeWalker',
+		data: { path, root: rootPath }
 	} );
 }
 
@@ -335,16 +365,16 @@ function checkCallDocumentListener( { node, context, path } ) {
  * document.body.appendChild( el ); // not allowed
  */
 function checkCallBodyAppendChild( { node, context, path } ) {
-	const match = path.match( /^(.+)\.body\.appendChild$/ );
+	const match = path.match( /^(.+)\.appendChild$/ );
 
-	if ( !match || !isDocumentAccessPath( match[ 1 ] ) ) {
+	if ( !match || !isDocumentBodyAccessPath( match[ 1 ] ) ) {
 		return;
 	}
 
 	context.report( {
 		node,
 		messageId: 'bodyAppendChild',
-		data: { path: `${ match[ 1 ] }.body` }
+		data: { path: match[ 1 ] }
 	} );
 }
 
@@ -420,6 +450,18 @@ function unwrapExpression( node ) {
  */
 function isDocumentAccessPath( path ) {
 	return /^(global\.)?(window\.)?document$/.test( path ) || /\.ownerDocument$/.test( path );
+}
+
+/**
+ * Checks whether a path refers to the body of the top-level document: `document.body`,
+ * `global.document.body`, `global.window.document.body`, or any `*.ownerDocument.body` access.
+ *
+ * isDocumentBodyAccessPath( 'global.document.body' ); // -> true
+ */
+function isDocumentBodyAccessPath( path ) {
+	const match = path.match( /^(.+)\.body$/ );
+
+	return Boolean( match ) && isDocumentAccessPath( match[ 1 ] );
 }
 
 /**

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
@@ -138,14 +138,16 @@ function checkMemberParentTraversal( { node, context } ) {
  * Flags calls to `getSelection()` in any global or cross-root form. A bare `getSelection()` call is
  * only flagged when it resolves to the global one, not to a locally imported or declared helper.
  *
- * global.window.getSelection(); // not allowed
+ * window.document.getSelection(); // not allowed
  */
 function checkCallGetSelection( { node, context, path } ) {
-	const isGlobalCall = /^(global\.)?(window|document)\.getSelection$/.test( path ) || path === 'global.getSelection';
-	const isCrossRootCall = /\.(ownerDocument|defaultView)\.getSelection$/.test( path );
-	const isBareGlobalCall = path === 'getSelection' && !isLocallyDefinedReference( { node: node.callee, context } );
+	const match = path.match( /^(.+)\.getSelection$/ );
+	const isPrefixedCall = Boolean( match ) &&
+		( match[ 1 ] === 'global' || isWindowAccessPath( match[ 1 ] ) || isDocumentAccessPath( match[ 1 ] ) );
+	const isBareGlobalCall = path === 'getSelection' &&
+		!isLocallyDefinedReference( { node: unwrapExpression( node.callee ), context } );
 
-	if ( !isBareGlobalCall && !isGlobalCall && !isCrossRootCall ) {
+	if ( !isBareGlobalCall && !isPrefixedCall ) {
 		return;
 	}
 
@@ -386,13 +388,23 @@ function unwrapExpression( node ) {
 }
 
 /**
- * Checks whether a path refers to the top-level document: `document`, `global.document`, or any
- * `*.ownerDocument` access.
+ * Checks whether a path refers to the top-level document: `document`, `window.document`,
+ * `global.document`, `global.window.document`, or any `*.ownerDocument` access.
  *
- * isDocumentAccessPath( 'global.document' ); // -> true
+ * isDocumentAccessPath( 'window.document' ); // -> true
  */
 function isDocumentAccessPath( path ) {
-	return /^(global\.)?document$/.test( path ) || /\.ownerDocument$/.test( path );
+	return /^(global\.)?(window\.)?document$/.test( path ) || /\.ownerDocument$/.test( path );
+}
+
+/**
+ * Checks whether a path refers to the top-level window: `window`, `global.window`, or any
+ * `*.defaultView` access.
+ *
+ * isWindowAccessPath( 'global.window' ); // -> true
+ */
+function isWindowAccessPath( path ) {
+	return /^(global\.)?window$/.test( path ) || /\.defaultView$/.test( path );
 }
 
 /**

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
@@ -30,6 +30,8 @@ module.exports = {
 				'always ignores Shadow DOM, regardless of any argument passed.',
 			documentElementLookup: 'Do not query `{{ path }}(...)` against the top-level document, query the ' +
 				'editor\'s own root instead — it finds nothing inside a shadow root.',
+			composedPath: 'Do not use `composedPath()` for root discovery, keep a held reference or use ' +
+				'`getRootNode()` instead.',
 			documentListener: 'Do not attach a `{{ event }}` listener on `{{ path }}` — ' +
 				'it will not fire for events inside other shadow roots.',
 			bodyAppendChild: 'Do not append directly to `{{ path }}` — it does not account for Shadow DOM boundaries.',
@@ -50,6 +52,7 @@ module.exports = {
 			checkCallElementFromPoint,
 			checkCallCaretFromPoint,
 			checkCallDocumentElementLookup,
+			checkCallComposedPath,
 			checkCallDocumentListener,
 			checkCallBodyAppendChild,
 			checkCallDocumentTreeWalker
@@ -296,6 +299,22 @@ function checkCallDocumentElementLookup( { node, context, path } ) {
 }
 
 /**
+ * Flags `composedPath()` used for root discovery.
+ *
+ * event.composedPath()[ 0 ]; // not allowed, use getRootNode()
+ */
+function checkCallComposedPath( { node, context, path } ) {
+	if ( !/(^|\.)composedPath$/.test( path ) ) {
+		return;
+	}
+
+	context.report( {
+		node,
+		messageId: 'composedPath'
+	} );
+}
+
+/**
  * Flags `createTreeWalker(...)` / `createNodeIterator(...)` rooted at the top-level document or its
  * body (`document`, `global.document`, `document.body`, `global.document.body`, or
  * `*.ownerDocument[.body]`), since neither traverses into descendant shadow roots.
@@ -465,8 +484,9 @@ function isWindowAccessPath( path ) {
 }
 
 /**
- * Checks whether an identifier reference resolves to a variable declared or imported in the source
- * (as opposed to an unresolved, implicitly global one).
+ * Checks whether an identifier reference resolves to a variable declared or imported in the source,
+ * as opposed to an unresolved global, a `global` directive comment-declared global, or a sloppy-mode
+ * implicit global created by an undeclared assignment.
  *
  * import { getSelection } from './shadow-dom-utils.js'; // -> resolves locally, not global
  */
@@ -479,7 +499,13 @@ function isLocallyDefinedReference( { node, context } ) {
 		const reference = scope.references.find( ref => ref.identifier === node );
 
 		if ( reference ) {
-			return Boolean( reference.resolved && reference.resolved.defs.length > 0 );
+			const variable = reference.resolved;
+
+			if ( !variable || variable.eslintExplicitGlobal ) {
+				return false;
+			}
+
+			return variable.defs.some( def => def.type !== 'ImplicitGlobalVariable' );
 		}
 
 		scope = scope.upper;

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
@@ -352,7 +352,22 @@ function getAccessPath( { node } ) {
 		return `${ getAccessPath( { node: node.callee } ) }()`;
 	}
 
+	// Unwrap TypeScript-only wrapper nodes (`x as Document`, `x!`, `<Document>x`, `x satisfies Document`)
+	// so a cast or non-null assertion doesn't hide the underlying access path.
+	if ( isTypeScriptWrapperExpression( node ) ) {
+		return getAccessPath( { node: node.expression } );
+	}
+
 	return '*';
+}
+
+/**
+ * Checks whether a node is a TypeScript-only wrapper expression around another expression.
+ *
+ * isTypeScriptWrapperExpression( node ); // node for `document!` -> true
+ */
+function isTypeScriptWrapperExpression( node ) {
+	return [ 'TSAsExpression', 'TSNonNullExpression', 'TSTypeAssertion', 'TSSatisfiesExpression' ].includes( node.type );
 }
 
 /**

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
@@ -226,7 +226,7 @@ function checkCallCaretFromPoint( { node, context, path } ) {
 	} );
 
 	function hasShadowRootsOption( { args } ) {
-		const lastArg = args[ args.length - 1 ];
+		const lastArg = unwrapExpression( args[ args.length - 1 ] );
 
 		return Boolean(
 			lastArg &&
@@ -289,7 +289,7 @@ function checkCallDocumentListener( { node, context, path } ) {
 		return;
 	}
 
-	const eventArg = node.arguments[ 0 ];
+	const eventArg = unwrapExpression( node.arguments[ 0 ] );
 	const eventName = eventArg && eventArg.type === 'Literal' ? eventArg.value : null;
 
 	if ( ![ 'mouseenter', 'mouseleave', 'scroll' ].includes( eventName ) ) {
@@ -325,7 +325,9 @@ function checkCallBodyAppendChild( { node, context, path } ) {
 
 /**
  * Builds a dotted string representation of a member/call path, collapsing computed and other
- * non-trivial segments to `*` so checks can rely on plain regexes.
+ * non-trivial segments to `*` so checks can rely on plain regexes. TypeScript wrapper nodes and
+ * parenthesized optional chains are unwrapped first, so a cast or a `(x?.y)` grouping doesn't hide
+ * the underlying access path.
  *
  * el.ownerDocument.defaultView.getSelection() -> 'el.ownerDocument.defaultView.getSelection()'
  */
@@ -334,28 +336,24 @@ function getAccessPath( { node } ) {
 		return '';
 	}
 
-	if ( node.type === 'Identifier' ) {
-		return node.name;
+	const unwrapped = unwrapExpression( node );
+
+	if ( unwrapped.type === 'Identifier' ) {
+		return unwrapped.name;
 	}
 
-	if ( node.type === 'ThisExpression' ) {
+	if ( unwrapped.type === 'ThisExpression' ) {
 		return 'this';
 	}
 
-	if ( node.type === 'MemberExpression' ) {
-		const propertyName = node.computed ? '*' : node.property.name;
+	if ( unwrapped.type === 'MemberExpression' ) {
+		const propertyName = unwrapped.computed ? '*' : unwrapped.property.name;
 
-		return `${ getAccessPath( { node: node.object } ) }.${ propertyName }`;
+		return `${ getAccessPath( { node: unwrapped.object } ) }.${ propertyName }`;
 	}
 
-	if ( node.type === 'CallExpression' ) {
-		return `${ getAccessPath( { node: node.callee } ) }()`;
-	}
-
-	// Unwrap TypeScript-only wrapper nodes (`x as Document`, `x!`, `<Document>x`, `x satisfies Document`)
-	// so a cast or non-null assertion doesn't hide the underlying access path.
-	if ( isTypeScriptWrapperExpression( node ) ) {
-		return getAccessPath( { node: node.expression } );
+	if ( unwrapped.type === 'CallExpression' ) {
+		return `${ getAccessPath( { node: unwrapped.callee } ) }()`;
 	}
 
 	return '*';
@@ -368,6 +366,23 @@ function getAccessPath( { node } ) {
  */
 function isTypeScriptWrapperExpression( node ) {
 	return [ 'TSAsExpression', 'TSNonNullExpression', 'TSTypeAssertion', 'TSSatisfiesExpression' ].includes( node.type );
+}
+
+/**
+ * Strips TypeScript wrapper nodes (`x as Document`, `x!`, `<Document>x`, `x satisfies Document`) and
+ * `ChainExpression` wrappers (parenthesized optional chains, e.g. `(x?.y)`) down to the expression
+ * underneath, since neither changes what is actually being accessed or called.
+ *
+ * unwrapExpression( node ); // node for `document!` -> node for `document`
+ */
+function unwrapExpression( node ) {
+	let current = node;
+
+	while ( current && ( isTypeScriptWrapperExpression( current ) || current.type === 'ChainExpression' ) ) {
+		current = current.expression;
+	}
+
+	return current;
 }
 
 /**

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
@@ -30,8 +30,6 @@ module.exports = {
 				'always ignores Shadow DOM, regardless of any argument passed.',
 			documentElementLookup: 'Do not query `{{ path }}(...)` against the top-level document, query the ' +
 				'editor\'s own root instead — it finds nothing inside a shadow root.',
-			composedPath: 'Do not use `composedPath()` for root discovery, keep a held reference or use ' +
-				'`getRootNode()` instead.',
 			documentListener: 'Do not attach a `{{ event }}` listener on `{{ path }}` — ' +
 				'it will not fire for events inside other shadow roots.',
 			bodyAppendChild: 'Do not append directly to `{{ path }}` — it does not account for Shadow DOM boundaries.',
@@ -52,7 +50,6 @@ module.exports = {
 			checkCallElementFromPoint,
 			checkCallCaretFromPoint,
 			checkCallDocumentElementLookup,
-			checkCallComposedPath,
 			checkCallDocumentListener,
 			checkCallBodyAppendChild,
 			checkCallDocumentTreeWalker
@@ -296,49 +293,6 @@ function checkCallDocumentElementLookup( { node, context, path } ) {
 		messageId: 'documentElementLookup',
 		data: { path }
 	} );
-}
-
-/**
- * Flags `composedPath()` only when it's used for root discovery — indexed or destructured right away
- * to pull out a single node. Keeping the result as an array and checking membership (`.includes(...)`,
- * `.some(...)`, etc.) is the correct, shadow-DOM-safe way to test ancestry and is not restricted here.
- *
- * event.composedPath()[ 0 ]; // not allowed, use getRootNode()
- * path.includes( contextElement ); // fine, not a root-discovery read
- */
-function checkCallComposedPath( { node, context, path } ) {
-	if ( !/(^|\.)composedPath$/.test( path ) || !isImmediatelyIndexedOrDestructured( node ) ) {
-		return;
-	}
-
-	context.report( {
-		node,
-		messageId: 'composedPath'
-	} );
-}
-
-/**
- * Checks whether a call expression's result is immediately indexed (`foo()[ 0 ]`) or array-destructured
- * (`const [ x ] = foo();` / `[ x ] = foo();`), as opposed to kept as a whole array.
- *
- * isImmediatelyIndexedOrDestructured( node ); // node for `event.composedPath()[ 0 ]` -> true
- */
-function isImmediatelyIndexedOrDestructured( node ) {
-	const parent = node.parent;
-
-	if ( parent.type === 'MemberExpression' && parent.object === node && parent.computed ) {
-		return true;
-	}
-
-	if ( parent.type === 'VariableDeclarator' && parent.init === node && parent.id.type === 'ArrayPattern' ) {
-		return true;
-	}
-
-	if ( parent.type === 'AssignmentExpression' && parent.right === node && parent.left.type === 'ArrayPattern' ) {
-		return true;
-	}
-
-	return false;
 }
 
 /**

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/no-shadow-unsafe-dom-apis.js
@@ -13,28 +13,28 @@ module.exports = {
 			category: 'CKEditor5'
 		},
 		messages: {
-			activeElement: 'Do not read `{{ path }}.activeElement` directly, use `getActiveElement()` — ' +
+			activeElement: 'Do not read `{{ path }}.activeElement` directly — ' +
 				'it is not tracked across Shadow DOM boundaries.',
-			shadowRootDiscovery: 'Do not use `.shadowRoot` for root discovery at read time. ' +
-				'Keep a held reference or use `getRootNode()`.',
-			parentTraversal: 'Do not traverse `.{{ property }}` directly, use `getParentOrHostElement()` ' +
-				'to cross Shadow DOM boundaries correctly.',
-			getSelection: 'Do not call `{{ path }}(...)` directly, use `getSelection()` from the Shadow DOM utils.',
-			contains: 'Do not use `{{ path }}(...)`, use `isConnected()` instead — ' +
+			shadowRootDiscovery: 'Do not use `.shadowRoot` for root discovery at read time, keep a held reference ' +
+				'or use `getRootNode()` instead.',
+			parentTraversal: 'Do not traverse `.{{ property }}` directly — ' +
+				'it does not cross Shadow DOM boundaries correctly.',
+			getSelection: 'Do not call `{{ path }}(...)` directly — it does not account for Shadow DOM boundaries.',
+			contains: 'Do not use `{{ path }}(...)`, use `isConnected` instead — ' +
 				'`contains()` does not cross Shadow DOM boundaries.',
 			elementFromPoint: 'Do not use `{{ path }}(...)` directly, resolve the point via the element\'s own root ' +
 				'— `{{ path }}` ignores Shadow DOM.',
 			caretFromPoint: 'Call `{{ path }}(...)` with a `{ shadowRoots }` option, ' +
 				'otherwise it will not resolve carets inside Shadow DOM.',
 			caretRangeFromPointUnsupported: 'Native `{{ path }}(...)` does not accept a `{ shadowRoots }` option and ' +
-				'always ignores Shadow DOM, regardless of any argument passed. Use `caretPositionFromPoint()` from ' +
-				'the Shadow DOM utils instead.',
+				'always ignores Shadow DOM, regardless of any argument passed.',
 			documentQuerySelector: 'Do not query `{{ path }}(...)` against the top-level document, query the ' +
 				'editor\'s own root instead — it finds nothing inside a shadow root.',
-			composedPath: 'Do not use `composedPath()` for root discovery, keep a held reference or use `getRootNode()`.',
-			documentListener: 'Do not attach a `{{ event }}` listener on `{{ path }}`, use a per-root ' +
-				'listener registry — it will not fire for events inside other shadow roots.',
-			bodyAppendChild: 'Do not append directly to `{{ path }}`, use the shadow-aware body-collection root.'
+			composedPath: 'Do not use `composedPath()` for root discovery, keep a held reference or use ' +
+				'`getRootNode()` instead.',
+			documentListener: 'Do not attach a `{{ event }}` listener on `{{ path }}` — ' +
+				'it will not fire for events inside other shadow roots.',
+			bodyAppendChild: 'Do not append directly to `{{ path }}` — it does not account for Shadow DOM boundaries.'
 		}
 	},
 	create( context ) {
@@ -82,7 +82,7 @@ module.exports = {
  * Flags reading `document.activeElement`, `global.document.activeElement`, or
  * `*.ownerDocument.activeElement`, which is not tracked across Shadow DOM boundaries.
  *
- * document.activeElement; // not allowed, use getActiveElement()
+ * document.activeElement; // not allowed
  */
 function checkMemberActiveElement( { node, context } ) {
 	if ( node.property.name !== 'activeElement' ) {
@@ -121,7 +121,7 @@ function checkMemberShadowRootDiscovery( { node, context } ) {
 /**
  * Flags raw `.parentNode` / `.parentElement` traversal, which does not cross Shadow DOM boundaries.
  *
- * el.parentNode; // not allowed, use getParentOrHostElement()
+ * el.parentNode; // not allowed
  */
 function checkMemberParentTraversal( { node, context } ) {
 	const propertyName = node.property.name;
@@ -167,7 +167,7 @@ function checkCallGetSelection( { node, context, path } ) {
  * `*.ownerDocument.body`), which does not cross Shadow DOM boundaries. A `.body.contains(...)` call
  * on a non-document object is not restricted here, since `body` is a common, unrelated property name.
  *
- * document.contains( el ); // not allowed, use isConnected()
+ * document.contains( el ); // not allowed, use isConnected
  */
 function checkCallContains( { node, context, path } ) {
 	const match = path.match( /^(.+)\.contains$/ );

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -44,6 +44,17 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
+			name: 'Calling a locally imported getSelection helper through an "as" cast',
+			code: 'import { getSelection } from \'./shadow-dom-utils.js\';\n' +
+				'const sel = ( getSelection as typeof getSelection )();\n'
+		},
+
+		{
+			name: 'Calling a locally imported getSelection helper through a non-null assertion',
+			code: 'import { getSelection } from \'./shadow-dom-utils.js\';\nconst sel = getSelection!();\n'
+		},
+
+		{
 			name: 'Calling isConnected instead of contains',
 			code: 'const connected = isConnected( el );\n'
 		},
@@ -116,6 +127,22 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
+			name: 'Reading window.document.activeElement',
+			code: 'const el = window.document.activeElement;\n',
+			errors: [
+				{ messageId: 'activeElement' }
+			]
+		},
+
+		{
+			name: 'Reading global.window.document.activeElement',
+			code: 'const el = global.window.document.activeElement;\n',
+			errors: [
+				{ messageId: 'activeElement' }
+			]
+		},
+
+		{
 			name: 'Reading *.ownerDocument.activeElement',
 			code: 'const el = someEl.ownerDocument.activeElement;\n',
 			errors: [
@@ -174,6 +201,14 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		{
 			name: 'Calling global.document.getSelection()',
 			code: 'const sel = global.document.getSelection();\n',
+			errors: [
+				{ messageId: 'getSelection' }
+			]
+		},
+
+		{
+			name: 'Calling window.document.getSelection()',
+			code: 'const sel = window.document.getSelection();\n',
 			errors: [
 				{ messageId: 'getSelection' }
 			]

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -47,6 +47,11 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
+			name: 'Calling .body.contains(...) on a non-document object',
+			code: 'const has = myWidget.body.contains( el );\n'
+		},
+
+		{
 			name: 'Calling elementFromPoint on a custom root, not on document',
 			code: 'const found = someRoot.elementFromPoint( x, y );\n'
 		},
@@ -142,6 +147,22 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
+			name: 'Calling global.window.getSelection()',
+			code: 'const sel = global.window.getSelection();\n',
+			errors: [
+				{ messageId: 'getSelection' }
+			]
+		},
+
+		{
+			name: 'Calling global.document.getSelection()',
+			code: 'const sel = global.document.getSelection();\n',
+			errors: [
+				{ messageId: 'getSelection' }
+			]
+		},
+
+		{
 			name: 'Calling *.ownerDocument.defaultView.getSelection()',
 			code: 'const sel = someEl.ownerDocument.defaultView.getSelection();\n',
 			errors: [
@@ -158,8 +179,24 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
+			name: 'Calling global.document.body.contains(...)',
+			code: 'global.document.body.contains( el );\n',
+			errors: [
+				{ messageId: 'contains' }
+			]
+		},
+
+		{
 			name: 'Calling *.ownerDocument.contains(...)',
 			code: 'someEl.ownerDocument.contains( el );\n',
+			errors: [
+				{ messageId: 'contains' }
+			]
+		},
+
+		{
+			name: 'Calling *.ownerDocument.body.contains(...)',
+			code: 'someEl.ownerDocument.body.contains( el );\n',
 			errors: [
 				{ messageId: 'contains' }
 			]

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -1,0 +1,235 @@
+/**
+ * @license Copyright (c) 2003-2026, CKSource Holding sp. z o.o. All rights reserved.
+ * For licensing, see LICENSE.md.
+ */
+
+'use strict';
+
+const { RuleTester } = require( 'eslint' );
+
+const ruleTester = new RuleTester( {
+	languageOptions: {
+		sourceType: 'module',
+		ecmaVersion: 2020
+	}
+} );
+
+ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', require( '../../lib/rules/no-shadow-unsafe-dom-apis' ), {
+	valid: [
+		{
+			name: 'Reading a property named activeElement on a custom object',
+			code: 'const el = someCustomObject.activeElement;\n'
+		},
+
+		{
+			name: 'Reading .shadowRoot is not restricted here (used by a different rule)',
+			code: 'const root = el.getRootNode();\n'
+		},
+
+		{
+			name: 'Traversing a custom parentNode-like helper, not a raw DOM one',
+			code: 'const parent = getParentOrHostElement( el );\n'
+		},
+
+		{
+			name: 'Calling getSelection from the Shadow DOM utils',
+			code: 'const sel = getSelectionFromShadowUtils( root );\n'
+		},
+
+		{
+			name: 'Calling isConnected instead of contains',
+			code: 'const connected = isConnected( el );\n'
+		},
+
+		{
+			name: 'Calling elementFromPoint on a custom root, not on document',
+			code: 'const found = someRoot.elementFromPoint( x, y );\n'
+		},
+
+		{
+			name: 'caretRangeFromPoint called with a { shadowRoots } option',
+			code: 'caretRangeFromPoint( x, y, { shadowRoots } );\n'
+		},
+
+		{
+			name: 'querySelector called on a custom root, not on the global document',
+			code: 'editingView.document.getRoot().querySelector( \'.foo\' );\n'
+		},
+
+		{
+			name: 'composedPath is not restricted here (used by a different rule)',
+			code: 'const root = getRootNode( el );\n'
+		},
+
+		{
+			name: 'addEventListener with an event other than mouseenter, mouseleave or scroll',
+			code: 'document.addEventListener( \'click\', listener );\n'
+		},
+
+		{
+			name: 'appendChild called on a custom body-collection root',
+			code: 'bodyCollectionRoot.appendChild( el );\n'
+		}
+	],
+	invalid: [
+		{
+			name: 'Reading document.activeElement',
+			code: 'const el = document.activeElement;\n',
+			errors: [
+				{ messageId: 'activeElement' }
+			]
+		},
+
+		{
+			name: 'Reading *.ownerDocument.activeElement',
+			code: 'const el = someEl.ownerDocument.activeElement;\n',
+			errors: [
+				{ messageId: 'activeElement' }
+			]
+		},
+
+		{
+			name: 'Reading .shadowRoot for root discovery',
+			code: 'const root = el.shadowRoot;\n',
+			errors: [
+				{ messageId: 'shadowRootDiscovery' }
+			]
+		},
+
+		{
+			name: 'Traversing .parentNode directly',
+			code: 'const parent = el.parentNode;\n',
+			errors: [
+				{ messageId: 'parentTraversal' }
+			]
+		},
+
+		{
+			name: 'Traversing .parentElement directly',
+			code: 'const parent = el.parentElement;\n',
+			errors: [
+				{ messageId: 'parentTraversal' }
+			]
+		},
+
+		{
+			name: 'Calling the bare, global getSelection()',
+			code: 'const sel = getSelection();\n',
+			errors: [
+				{ messageId: 'getSelection' }
+			]
+		},
+
+		{
+			name: 'Calling window.getSelection()',
+			code: 'const sel = window.getSelection();\n',
+			errors: [
+				{ messageId: 'getSelection' }
+			]
+		},
+
+		{
+			name: 'Calling *.ownerDocument.defaultView.getSelection()',
+			code: 'const sel = someEl.ownerDocument.defaultView.getSelection();\n',
+			errors: [
+				{ messageId: 'getSelection' }
+			]
+		},
+
+		{
+			name: 'Calling document.body.contains(...)',
+			code: 'document.body.contains( el );\n',
+			errors: [
+				{ messageId: 'contains' }
+			]
+		},
+
+		{
+			name: 'Calling *.ownerDocument.contains(...)',
+			code: 'someEl.ownerDocument.contains( el );\n',
+			errors: [
+				{ messageId: 'contains' }
+			]
+		},
+
+		{
+			name: 'Calling document.elementFromPoint(...)',
+			code: 'document.elementFromPoint( x, y );\n',
+			errors: [
+				{ messageId: 'elementFromPoint' }
+			]
+		},
+
+		{
+			name: 'Calling document.elementsFromPoint(...)',
+			code: 'document.elementsFromPoint( x, y );\n',
+			errors: [
+				{ messageId: 'elementFromPoint' }
+			]
+		},
+
+		{
+			name: 'Calling document.caretRangeFromPoint(...) without { shadowRoots }',
+			code: 'document.caretRangeFromPoint( x, y );\n',
+			errors: [
+				{ messageId: 'caretFromPoint' }
+			]
+		},
+
+		{
+			name: 'Calling caretPositionFromPoint(...) without { shadowRoots }',
+			code: 'caretPositionFromPoint( x, y );\n',
+			errors: [
+				{ messageId: 'caretFromPoint' }
+			]
+		},
+
+		{
+			name: 'Calling document.querySelector(...) against the global document',
+			code: 'document.querySelector( \'.foo\' );\n',
+			errors: [
+				{ messageId: 'globalQuerySelector' }
+			]
+		},
+
+		{
+			name: 'Calling document.getElementById(...) against the global document',
+			code: 'document.getElementById( \'foo\' );\n',
+			errors: [
+				{ messageId: 'globalQuerySelector' }
+			]
+		},
+
+		{
+			name: 'Using composedPath() for root discovery',
+			code: 'const root = event.composedPath()[ 0 ];\n',
+			errors: [
+				{ messageId: 'composedPath' }
+			]
+		},
+
+		{
+			name: 'Attaching a global mouseenter listener on document',
+			code: 'document.addEventListener( \'mouseenter\', listener );\n',
+			errors: [
+				{ messageId: 'globalDocumentListener' }
+			]
+		},
+
+		{
+			name: 'Attaching a global scroll listener on global.document',
+			code: 'global.document.addEventListener( \'scroll\', listener );\n',
+			errors: [
+				{ messageId: 'globalDocumentListener' }
+			]
+		},
+
+		{
+			name: 'Appending directly to document.body',
+			code: 'document.body.appendChild( el );\n',
+			errors: [
+				{ messageId: 'bodyAppendChild' }
+			]
+		}
+	]
+} );

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -548,6 +548,22 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
+			name: 'Appending directly to window.document.body',
+			code: 'window.document.body.appendChild( el );\n',
+			errors: [
+				{ messageId: 'bodyAppendChild' }
+			]
+		},
+
+		{
+			name: 'Appending directly to global.window.document.body',
+			code: 'global.window.document.body.appendChild( el );\n',
+			errors: [
+				{ messageId: 'bodyAppendChild' }
+			]
+		},
+
+		{
 			name: 'Appending directly to *.ownerDocument.body',
 			code: 'someEl.ownerDocument.body.appendChild( el );\n',
 			errors: [

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -117,6 +117,21 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		{
 			name: 'Casting a custom object, not a document access path',
 			code: 'const el = ( someCustomObject as Foo ).activeElement;\n'
+		},
+
+		{
+			name: 'Reading a private #shadowRoot field, not the DOM shadowRoot property',
+			code: 'class Foo { #shadowRoot; bar() { return this.#shadowRoot; } }\n'
+		},
+
+		{
+			name: 'Reading a private #parentNode field, not the DOM parentNode property',
+			code: 'class Foo { #parentNode; bar() { return this.#parentNode; } }\n'
+		},
+
+		{
+			name: 'Reading activeElement off a private #ownerDocument field, not the real ownerDocument',
+			code: 'class Foo { #ownerDocument; bar() { return this.#ownerDocument.activeElement; } }\n'
 		}
 	],
 	invalid: [

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -364,6 +364,22 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
+			name: 'Calling window.document.elementFromPoint(...)',
+			code: 'window.document.elementFromPoint( x, y );\n',
+			errors: [
+				{ messageId: 'elementFromPoint' }
+			]
+		},
+
+		{
+			name: 'Calling global.window.document.elementFromPoint(...)',
+			code: 'global.window.document.elementFromPoint( x, y );\n',
+			errors: [
+				{ messageId: 'elementFromPoint' }
+			]
+		},
+
+		{
 			name: 'Calling *.ownerDocument.elementFromPoint(...)',
 			code: 'someEl.ownerDocument.elementFromPoint( x, y );\n',
 			errors: [

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -183,6 +183,14 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
+			name: 'Calling document.getSelection()',
+			code: 'const sel = document.getSelection();\n',
+			errors: [
+				{ messageId: 'getSelection' }
+			]
+		},
+
+		{
 			name: 'Calling window.getSelection()',
 			code: 'const sel = window.getSelection();\n',
 			errors: [

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -125,16 +125,6 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
-			name: 'Checking ancestry via composedPath().includes(...) kept as an array',
-			code: 'const path = event.composedPath();\npath.includes( contextElement );\n'
-		},
-
-		{
-			name: 'Checking ancestry via composedPath().includes(...) chained directly',
-			code: 'event.composedPath().includes( contextElement );\n'
-		},
-
-		{
 			name: 'addEventListener with an event other than mouseenter, mouseleave or scroll',
 			code: 'document.addEventListener( \'click\', listener );\n'
 		},
@@ -594,30 +584,6 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 			code: 'someEl.ownerDocument.getElementsByTagName( \'p\' );\n',
 			errors: [
 				{ messageId: 'documentElementLookup' }
-			]
-		},
-
-		{
-			name: 'Using composedPath() for root discovery',
-			code: 'const root = event.composedPath()[ 0 ];\n',
-			errors: [
-				{ messageId: 'composedPath' }
-			]
-		},
-
-		{
-			name: 'Destructuring the first node out of composedPath() via a declaration',
-			code: 'const [ target ] = event.composedPath();\n',
-			errors: [
-				{ messageId: 'composedPath' }
-			]
-		},
-
-		{
-			name: 'Destructuring the first node out of composedPath() via an assignment',
-			code: '[ target ] = event.composedPath();\n',
-			errors: [
-				{ messageId: 'composedPath' }
 			]
 		},
 

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -125,6 +125,16 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
+			name: 'Checking ancestry via composedPath().includes(...) kept as an array',
+			code: 'const path = event.composedPath();\npath.includes( contextElement );\n'
+		},
+
+		{
+			name: 'Checking ancestry via composedPath().includes(...) chained directly',
+			code: 'event.composedPath().includes( contextElement );\n'
+		},
+
+		{
 			name: 'addEventListener with an event other than mouseenter, mouseleave or scroll',
 			code: 'document.addEventListener( \'click\', listener );\n'
 		},
@@ -590,6 +600,22 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		{
 			name: 'Using composedPath() for root discovery',
 			code: 'const root = event.composedPath()[ 0 ];\n',
+			errors: [
+				{ messageId: 'composedPath' }
+			]
+		},
+
+		{
+			name: 'Destructuring the first node out of composedPath() via a declaration',
+			code: 'const [ target ] = event.composedPath();\n',
+			errors: [
+				{ messageId: 'composedPath' }
+			]
+		},
+
+		{
+			name: 'Destructuring the first node out of composedPath() via an assignment',
+			code: '[ target ] = event.composedPath();\n',
 			errors: [
 				{ messageId: 'composedPath' }
 			]

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -115,6 +115,11 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
+			name: 'Calling .body.querySelector(...) on a non-document object',
+			code: 'const found = myWidget.body.querySelector( \'.foo\' );\n'
+		},
+
+		{
 			name: 'composedPath is not restricted here (used by a different rule)',
 			code: 'const root = getRootNode( el );\n'
 		},
@@ -505,6 +510,14 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		{
 			name: 'Calling document.getElementById(...) against the top-level document',
 			code: 'document.getElementById( \'foo\' );\n',
+			errors: [
+				{ messageId: 'documentElementLookup' }
+			]
+		},
+
+		{
+			name: 'Calling document.body.querySelectorAll(...)',
+			code: 'document.body.querySelectorAll( \'.foo\' );\n',
 			errors: [
 				{ messageId: 'documentElementLookup' }
 			]

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -115,11 +115,6 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
-			name: 'Calling .body.querySelector(...) on a non-document object',
-			code: 'const found = myWidget.body.querySelector( \'.foo\' );\n'
-		},
-
-		{
 			name: 'composedPath is not restricted here (used by a different rule)',
 			code: 'const root = getRootNode( el );\n'
 		},
@@ -222,6 +217,14 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		{
 			name: 'Calling the bare, unresolved global getSelection()',
 			code: 'const sel = getSelection();\n',
+			errors: [
+				{ messageId: 'getSelection' }
+			]
+		},
+
+		{
+			name: 'Calling getSelection() declared global via a /* global */ directive comment',
+			code: '/* global getSelection */\nconst sel = getSelection();\n',
 			errors: [
 				{ messageId: 'getSelection' }
 			]
@@ -516,14 +519,6 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
-			name: 'Calling document.body.querySelectorAll(...)',
-			code: 'document.body.querySelectorAll( \'.foo\' );\n',
-			errors: [
-				{ messageId: 'documentElementLookup' }
-			]
-		},
-
-		{
 			name: 'Calling global.document.querySelector(...)',
 			code: 'global.document.querySelector( \'.foo\' );\n',
 			errors: [
@@ -584,6 +579,14 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 			code: 'someEl.ownerDocument.getElementsByTagName( \'p\' );\n',
 			errors: [
 				{ messageId: 'documentElementLookup' }
+			]
+		},
+
+		{
+			name: 'Using composedPath() for root discovery',
+			code: 'const root = event.composedPath()[ 0 ];\n',
+			errors: [
+				{ messageId: 'composedPath' }
 			]
 		},
 

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -188,6 +188,14 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
+			name: 'Calling global.getSelection()',
+			code: 'const sel = global.getSelection();\n',
+			errors: [
+				{ messageId: 'getSelection' }
+			]
+		},
+
+		{
 			name: 'Calling document.getSelection()',
 			code: 'const sel = document.getSelection();\n',
 			errors: [
@@ -222,6 +230,22 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		{
 			name: 'Calling window.document.getSelection()',
 			code: 'const sel = window.document.getSelection();\n',
+			errors: [
+				{ messageId: 'getSelection' }
+			]
+		},
+
+		{
+			name: 'Calling global.window.document.getSelection()',
+			code: 'const sel = global.window.document.getSelection();\n',
+			errors: [
+				{ messageId: 'getSelection' }
+			]
+		},
+
+		{
+			name: 'Calling *.ownerDocument.getSelection()',
+			code: 'const sel = someEl.ownerDocument.getSelection();\n',
 			errors: [
 				{ messageId: 'getSelection' }
 			]

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -70,6 +70,21 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
+			name: 'Calling getElementsByTagName on a custom root, not on document',
+			code: 'const found = someRoot.getElementsByTagName( \'p\' );\n'
+		},
+
+		{
+			name: 'Creating a TreeWalker rooted at a shadow root, not at the top-level document',
+			code: 'document.createTreeWalker( shadowRoot, NodeFilter.SHOW_ELEMENT );\n'
+		},
+
+		{
+			name: 'Creating a TreeWalker rooted at an arbitrary element, not at the top-level document',
+			code: 'document.createTreeWalker( someElement, NodeFilter.SHOW_ELEMENT );\n'
+		},
+
+		{
 			name: 'caretRangeFromPoint called with a { shadowRoots } option',
 			code: 'caretRangeFromPoint( x, y, { shadowRoots } );\n'
 		},
@@ -483,7 +498,7 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 			name: 'Calling document.querySelector(...) against the top-level document',
 			code: 'document.querySelector( \'.foo\' );\n',
 			errors: [
-				{ messageId: 'documentQuerySelector' }
+				{ messageId: 'documentElementLookup' }
 			]
 		},
 
@@ -491,7 +506,7 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 			name: 'Calling document.getElementById(...) against the top-level document',
 			code: 'document.getElementById( \'foo\' );\n',
 			errors: [
-				{ messageId: 'documentQuerySelector' }
+				{ messageId: 'documentElementLookup' }
 			]
 		},
 
@@ -499,7 +514,7 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 			name: 'Calling global.document.querySelector(...)',
 			code: 'global.document.querySelector( \'.foo\' );\n',
 			errors: [
-				{ messageId: 'documentQuerySelector' }
+				{ messageId: 'documentElementLookup' }
 			]
 		},
 
@@ -507,7 +522,7 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 			name: 'Calling window.document.querySelector(...)',
 			code: 'window.document.querySelector( \'.foo\' );\n',
 			errors: [
-				{ messageId: 'documentQuerySelector' }
+				{ messageId: 'documentElementLookup' }
 			]
 		},
 
@@ -515,7 +530,7 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 			name: 'Calling global.window.document.querySelector(...)',
 			code: 'global.window.document.querySelector( \'.foo\' );\n',
 			errors: [
-				{ messageId: 'documentQuerySelector' }
+				{ messageId: 'documentElementLookup' }
 			]
 		},
 
@@ -523,7 +538,39 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 			name: 'Calling *.ownerDocument.querySelector(...)',
 			code: 'someEl.ownerDocument.querySelector( \'.foo\' );\n',
 			errors: [
-				{ messageId: 'documentQuerySelector' }
+				{ messageId: 'documentElementLookup' }
+			]
+		},
+
+		{
+			name: 'Calling document.getElementsByTagName(...)',
+			code: 'document.getElementsByTagName( \'p\' );\n',
+			errors: [
+				{ messageId: 'documentElementLookup' }
+			]
+		},
+
+		{
+			name: 'Calling document.getElementsByClassName(...)',
+			code: 'document.getElementsByClassName( \'foo\' );\n',
+			errors: [
+				{ messageId: 'documentElementLookup' }
+			]
+		},
+
+		{
+			name: 'Calling document.getElementsByName(...)',
+			code: 'document.getElementsByName( \'foo\' );\n',
+			errors: [
+				{ messageId: 'documentElementLookup' }
+			]
+		},
+
+		{
+			name: 'Calling *.ownerDocument.getElementsByTagName(...)',
+			code: 'someEl.ownerDocument.getElementsByTagName( \'p\' );\n',
+			errors: [
+				{ messageId: 'documentElementLookup' }
 			]
 		},
 
@@ -532,6 +579,38 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 			code: 'const root = event.composedPath()[ 0 ];\n',
 			errors: [
 				{ messageId: 'composedPath' }
+			]
+		},
+
+		{
+			name: 'Creating a TreeWalker rooted at document.body',
+			code: 'document.createTreeWalker( document.body, NodeFilter.SHOW_ELEMENT );\n',
+			errors: [
+				{ messageId: 'documentTreeWalker' }
+			]
+		},
+
+		{
+			name: 'Creating a TreeWalker rooted directly at document',
+			code: 'document.createTreeWalker( document, NodeFilter.SHOW_ELEMENT );\n',
+			errors: [
+				{ messageId: 'documentTreeWalker' }
+			]
+		},
+
+		{
+			name: 'Creating a NodeIterator rooted at global.document.body',
+			code: 'document.createNodeIterator( global.document.body, NodeFilter.SHOW_ELEMENT );\n',
+			errors: [
+				{ messageId: 'documentTreeWalker' }
+			]
+		},
+
+		{
+			name: 'Creating a TreeWalker rooted at *.ownerDocument',
+			code: 'document.createTreeWalker( someEl.ownerDocument, NodeFilter.SHOW_ELEMENT );\n',
+			errors: [
+				{ messageId: 'documentTreeWalker' }
 			]
 		},
 
@@ -635,7 +714,7 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 			name: 'Calling document.querySelector(...) through optional chaining',
 			code: 'document?.querySelector( \'.foo\' );\n',
 			errors: [
-				{ messageId: 'documentQuerySelector' }
+				{ messageId: 'documentElementLookup' }
 			]
 		},
 
@@ -659,7 +738,7 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 			name: 'Calling querySelector through a TSNonNullExpression on document',
 			code: 'document!.querySelector( \'.foo\' );\n',
 			errors: [
-				{ messageId: 'documentQuerySelector' }
+				{ messageId: 'documentElementLookup' }
 			]
 		},
 

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -64,6 +64,16 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
+			name: 'caretRangeFromPoint called with a { shadowRoots } option wrapped in an "as" cast',
+			code: 'caretRangeFromPoint( x, y, ( { shadowRoots } as CaretFromPointOptions ) );\n'
+		},
+
+		{
+			name: 'caretRangeFromPoint called with a { shadowRoots } option wrapped in a non-null assertion',
+			code: 'caretRangeFromPoint( x, y, { shadowRoots }! );\n'
+		},
+
+		{
 			name: 'querySelector called on a custom root, not on the top-level document',
 			code: 'editingView.document.getRoot().querySelector( \'.foo\' );\n'
 		},
@@ -414,6 +424,30 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 			code: '( someEl.ownerDocument as Document ).contains( el );\n',
 			errors: [
 				{ messageId: 'contains' }
+			]
+		},
+
+		{
+			name: 'Attaching a scroll listener where the event name is wrapped in "as const"',
+			code: 'document.addEventListener( \'scroll\' as const, listener );\n',
+			errors: [
+				{ messageId: 'documentListener' }
+			]
+		},
+
+		{
+			name: 'Calling contains through a parenthesized optional chain',
+			code: '( document?.body ).contains( el );\n',
+			errors: [
+				{ messageId: 'contains' }
+			]
+		},
+
+		{
+			name: 'Calling appendChild through a parenthesized optional chain',
+			code: '( document?.body ).appendChild( el );\n',
+			errors: [
+				{ messageId: 'bodyAppendChild' }
 			]
 		}
 	]

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -171,6 +171,22 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
+			name: 'Calling document.contains(...)',
+			code: 'document.contains( el );\n',
+			errors: [
+				{ messageId: 'contains' }
+			]
+		},
+
+		{
+			name: 'Calling global.document.contains(...)',
+			code: 'global.document.contains( el );\n',
+			errors: [
+				{ messageId: 'contains' }
+			]
+		},
+
+		{
 			name: 'Calling document.body.contains(...)',
 			code: 'document.body.contains( el );\n',
 			errors: [
@@ -291,18 +307,26 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
-			name: 'Attaching a global mouseenter listener on document',
+			name: 'Attaching a mouseenter listener on document',
 			code: 'document.addEventListener( \'mouseenter\', listener );\n',
 			errors: [
-				{ messageId: 'globalDocumentListener' }
+				{ messageId: 'documentListener' }
 			]
 		},
 
 		{
-			name: 'Attaching a global scroll listener on global.document',
+			name: 'Attaching a scroll listener on global.document',
 			code: 'global.document.addEventListener( \'scroll\', listener );\n',
 			errors: [
-				{ messageId: 'globalDocumentListener' }
+				{ messageId: 'documentListener' }
+			]
+		},
+
+		{
+			name: 'Attaching a mouseleave listener on *.ownerDocument',
+			code: 'someEl.ownerDocument.addEventListener( \'mouseleave\', listener );\n',
+			errors: [
+				{ messageId: 'documentListener' }
 			]
 		},
 
@@ -327,6 +351,30 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 			code: 'someEl.ownerDocument.body.appendChild( el );\n',
 			errors: [
 				{ messageId: 'bodyAppendChild' }
+			]
+		},
+
+		{
+			name: 'Traversing .parentNode through optional chaining',
+			code: 'const parent = el?.parentNode;\n',
+			errors: [
+				{ messageId: 'parentTraversal' }
+			]
+		},
+
+		{
+			name: 'Reading document.activeElement through optional chaining',
+			code: 'const el = document?.activeElement;\n',
+			errors: [
+				{ messageId: 'activeElement' }
+			]
+		},
+
+		{
+			name: 'Calling document.querySelector(...) through optional chaining',
+			code: 'document?.querySelector( \'.foo\' );\n',
+			errors: [
+				{ messageId: 'documentQuerySelector' }
 			]
 		}
 	]

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -508,6 +508,22 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
+			name: 'Attaching a scroll listener on window.document',
+			code: 'window.document.addEventListener( \'scroll\', listener );\n',
+			errors: [
+				{ messageId: 'documentListener' }
+			]
+		},
+
+		{
+			name: 'Attaching a mouseenter listener on global.window.document',
+			code: 'global.window.document.addEventListener( \'mouseenter\', listener );\n',
+			errors: [
+				{ messageId: 'documentListener' }
+			]
+		},
+
+		{
 			name: 'Attaching a mouseleave listener on *.ownerDocument',
 			code: 'someEl.ownerDocument.addEventListener( \'mouseleave\', listener );\n',
 			errors: [

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -276,6 +276,22 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
+			name: 'Calling window.document.contains(...)',
+			code: 'window.document.contains( el );\n',
+			errors: [
+				{ messageId: 'contains' }
+			]
+		},
+
+		{
+			name: 'Calling global.window.document.contains(...)',
+			code: 'global.window.document.contains( el );\n',
+			errors: [
+				{ messageId: 'contains' }
+			]
+		},
+
+		{
 			name: 'Calling document.body.contains(...)',
 			code: 'document.body.contains( el );\n',
 			errors: [
@@ -286,6 +302,22 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		{
 			name: 'Calling global.document.body.contains(...)',
 			code: 'global.document.body.contains( el );\n',
+			errors: [
+				{ messageId: 'contains' }
+			]
+		},
+
+		{
+			name: 'Calling window.document.body.contains(...)',
+			code: 'window.document.body.contains( el );\n',
+			errors: [
+				{ messageId: 'contains' }
+			]
+		},
+
+		{
+			name: 'Calling global.window.document.body.contains(...)',
+			code: 'global.window.document.body.contains( el );\n',
 			errors: [
 				{ messageId: 'contains' }
 			]

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -460,6 +460,22 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
+			name: 'Calling window.document.querySelector(...)',
+			code: 'window.document.querySelector( \'.foo\' );\n',
+			errors: [
+				{ messageId: 'documentQuerySelector' }
+			]
+		},
+
+		{
+			name: 'Calling global.window.document.querySelector(...)',
+			code: 'global.window.document.querySelector( \'.foo\' );\n',
+			errors: [
+				{ messageId: 'documentQuerySelector' }
+			]
+		},
+
+		{
 			name: 'Calling *.ownerDocument.querySelector(...)',
 			code: 'someEl.ownerDocument.querySelector( \'.foo\' );\n',
 			errors: [

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -644,6 +644,22 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
+			name: 'Attaching a pointerenter listener on document',
+			code: 'document.addEventListener( \'pointerenter\', listener );\n',
+			errors: [
+				{ messageId: 'documentListener' }
+			]
+		},
+
+		{
+			name: 'Attaching a pointerleave listener on global.document',
+			code: 'global.document.addEventListener( \'pointerleave\', listener );\n',
+			errors: [
+				{ messageId: 'documentListener' }
+			]
+		},
+
+		{
 			name: 'Attaching a scroll listener on global.document',
 			code: 'global.document.addEventListener( \'scroll\', listener );\n',
 			errors: [

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -115,6 +115,11 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
+			name: 'Calling .body.querySelector(...) on a non-document object',
+			code: 'const found = myWidget.body.querySelector( \'.foo\' );\n'
+		},
+
+		{
 			name: 'composedPath is not restricted here (used by a different rule)',
 			code: 'const root = getRootNode( el );\n'
 		},
@@ -513,6 +518,14 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		{
 			name: 'Calling document.getElementById(...) against the top-level document',
 			code: 'document.getElementById( \'foo\' );\n',
+			errors: [
+				{ messageId: 'documentElementLookup' }
+			]
+		},
+
+		{
+			name: 'Calling document.body.querySelectorAll(...)',
+			code: 'document.body.querySelectorAll( \'.foo\' );\n',
 			errors: [
 				{ messageId: 'documentElementLookup' }
 			]

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -32,8 +32,13 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
-			name: 'Calling getSelection from the Shadow DOM utils',
-			code: 'const sel = getSelectionFromShadowUtils( root );\n'
+			name: 'Calling a locally imported helper also named getSelection',
+			code: 'import { getSelection } from \'./shadow-dom-utils.js\';\nconst sel = getSelection();\n'
+		},
+
+		{
+			name: 'Calling a locally declared function also named getSelection',
+			code: 'function getSelection() { return null; }\nconst sel = getSelection();\n'
 		},
 
 		{
@@ -52,7 +57,7 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
-			name: 'querySelector called on a custom root, not on the global document',
+			name: 'querySelector called on a custom root, not on the top-level document',
 			code: 'editingView.document.getRoot().querySelector( \'.foo\' );\n'
 		},
 
@@ -75,6 +80,14 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		{
 			name: 'Reading document.activeElement',
 			code: 'const el = document.activeElement;\n',
+			errors: [
+				{ messageId: 'activeElement' }
+			]
+		},
+
+		{
+			name: 'Reading global.document.activeElement',
+			code: 'const el = global.document.activeElement;\n',
 			errors: [
 				{ messageId: 'activeElement' }
 			]
@@ -113,7 +126,7 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
-			name: 'Calling the bare, global getSelection()',
+			name: 'Calling the bare, unresolved global getSelection()',
 			code: 'const sel = getSelection();\n',
 			errors: [
 				{ messageId: 'getSelection' }
@@ -169,6 +182,22 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
+			name: 'Calling global.document.elementFromPoint(...)',
+			code: 'global.document.elementFromPoint( x, y );\n',
+			errors: [
+				{ messageId: 'elementFromPoint' }
+			]
+		},
+
+		{
+			name: 'Calling *.ownerDocument.elementFromPoint(...)',
+			code: 'someEl.ownerDocument.elementFromPoint( x, y );\n',
+			errors: [
+				{ messageId: 'elementFromPoint' }
+			]
+		},
+
+		{
 			name: 'Calling document.caretRangeFromPoint(...) without { shadowRoots }',
 			code: 'document.caretRangeFromPoint( x, y );\n',
 			errors: [
@@ -185,18 +214,34 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
-			name: 'Calling document.querySelector(...) against the global document',
+			name: 'Calling document.querySelector(...) against the top-level document',
 			code: 'document.querySelector( \'.foo\' );\n',
 			errors: [
-				{ messageId: 'globalQuerySelector' }
+				{ messageId: 'documentQuerySelector' }
 			]
 		},
 
 		{
-			name: 'Calling document.getElementById(...) against the global document',
+			name: 'Calling document.getElementById(...) against the top-level document',
 			code: 'document.getElementById( \'foo\' );\n',
 			errors: [
-				{ messageId: 'globalQuerySelector' }
+				{ messageId: 'documentQuerySelector' }
+			]
+		},
+
+		{
+			name: 'Calling global.document.querySelector(...)',
+			code: 'global.document.querySelector( \'.foo\' );\n',
+			errors: [
+				{ messageId: 'documentQuerySelector' }
+			]
+		},
+
+		{
+			name: 'Calling *.ownerDocument.querySelector(...)',
+			code: 'someEl.ownerDocument.querySelector( \'.foo\' );\n',
+			errors: [
+				{ messageId: 'documentQuerySelector' }
 			]
 		},
 
@@ -227,6 +272,22 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		{
 			name: 'Appending directly to document.body',
 			code: 'document.body.appendChild( el );\n',
+			errors: [
+				{ messageId: 'bodyAppendChild' }
+			]
+		},
+
+		{
+			name: 'Appending directly to global.document.body',
+			code: 'global.document.body.appendChild( el );\n',
+			errors: [
+				{ messageId: 'bodyAppendChild' }
+			]
+		},
+
+		{
+			name: 'Appending directly to *.ownerDocument.body',
+			code: 'someEl.ownerDocument.body.appendChild( el );\n',
 			errors: [
 				{ messageId: 'bodyAppendChild' }
 			]

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -90,6 +90,11 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
+			name: 'caretRangeFromPoint called on a non-document object with a { shadowRoots } option',
+			code: 'someRoot.caretRangeFromPoint( x, y, { shadowRoots } );\n'
+		},
+
+		{
 			name: 'querySelector called on a custom root, not on the top-level document',
 			code: 'editingView.document.getRoot().querySelector( \'.foo\' );\n'
 		},
@@ -412,10 +417,34 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
+			name: 'Calling window.document.caretRangeFromPoint(...)',
+			code: 'window.document.caretRangeFromPoint( x, y, { shadowRoots } );\n',
+			errors: [
+				{ messageId: 'caretRangeFromPointUnsupported' }
+			]
+		},
+
+		{
+			name: 'Calling global.window.document.caretRangeFromPoint(...)',
+			code: 'global.window.document.caretRangeFromPoint( x, y, { shadowRoots } );\n',
+			errors: [
+				{ messageId: 'caretRangeFromPointUnsupported' }
+			]
+		},
+
+		{
 			name: 'Calling *.ownerDocument.caretRangeFromPoint(...)',
 			code: 'someEl.ownerDocument.caretRangeFromPoint( x, y, { shadowRoots } );\n',
 			errors: [
 				{ messageId: 'caretRangeFromPointUnsupported' }
+			]
+		},
+
+		{
+			name: 'Calling caretRangeFromPoint(...) on a non-document object without { shadowRoots }',
+			code: 'someRoot.caretRangeFromPoint( x, y );\n',
+			errors: [
+				{ messageId: 'caretFromPoint' }
 			]
 		},
 

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -85,6 +85,11 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		},
 
 		{
+			name: 'document.caretPositionFromPoint called with a { shadowRoots } option',
+			code: 'document.caretPositionFromPoint( x, y, { shadowRoots } );\n'
+		},
+
+		{
 			name: 'querySelector called on a custom root, not on the top-level document',
 			code: 'editingView.document.getRoot().querySelector( \'.foo\' );\n'
 		},
@@ -313,6 +318,38 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		{
 			name: 'Calling document.caretRangeFromPoint(...) without { shadowRoots }',
 			code: 'document.caretRangeFromPoint( x, y );\n',
+			errors: [
+				{ messageId: 'caretRangeFromPointUnsupported' }
+			]
+		},
+
+		{
+			name: 'Calling document.caretRangeFromPoint(...) with { shadowRoots }, which is a no-op natively',
+			code: 'document.caretRangeFromPoint( x, y, { shadowRoots } );\n',
+			errors: [
+				{ messageId: 'caretRangeFromPointUnsupported' }
+			]
+		},
+
+		{
+			name: 'Calling global.document.caretRangeFromPoint(...)',
+			code: 'global.document.caretRangeFromPoint( x, y, { shadowRoots } );\n',
+			errors: [
+				{ messageId: 'caretRangeFromPointUnsupported' }
+			]
+		},
+
+		{
+			name: 'Calling *.ownerDocument.caretRangeFromPoint(...)',
+			code: 'someEl.ownerDocument.caretRangeFromPoint( x, y, { shadowRoots } );\n',
+			errors: [
+				{ messageId: 'caretRangeFromPointUnsupported' }
+			]
+		},
+
+		{
+			name: 'Calling document.caretPositionFromPoint(...) without { shadowRoots }',
+			code: 'document.caretPositionFromPoint( x, y );\n',
 			errors: [
 				{ messageId: 'caretFromPoint' }
 			]

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/no-shadow-unsafe-dom-apis.js
@@ -6,11 +6,13 @@
 'use strict';
 
 const { RuleTester } = require( 'eslint' );
+const tsParser = require( '@typescript-eslint/parser' );
 
 const ruleTester = new RuleTester( {
 	languageOptions: {
 		sourceType: 'module',
-		ecmaVersion: 2020
+		ecmaVersion: 2020,
+		parser: tsParser
 	}
 } );
 
@@ -79,6 +81,11 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 		{
 			name: 'appendChild called on a custom body-collection root',
 			code: 'bodyCollectionRoot.appendChild( el );\n'
+		},
+
+		{
+			name: 'Casting a custom object, not a document access path',
+			code: 'const el = ( someCustomObject as Foo ).activeElement;\n'
 		}
 	],
 	invalid: [
@@ -375,6 +382,38 @@ ruleTester.run( 'eslint-plugin-ckeditor5-rules/no-shadow-unsafe-dom-apis', requi
 			code: 'document?.querySelector( \'.foo\' );\n',
 			errors: [
 				{ messageId: 'documentQuerySelector' }
+			]
+		},
+
+		{
+			name: 'Reading activeElement through a TSAsExpression cast on ownerDocument',
+			code: 'const el = ( element.ownerDocument as Document ).activeElement;\n',
+			errors: [
+				{ messageId: 'activeElement' }
+			]
+		},
+
+		{
+			name: 'Reading activeElement through a TSNonNullExpression on document',
+			code: 'const el = document!.activeElement;\n',
+			errors: [
+				{ messageId: 'activeElement' }
+			]
+		},
+
+		{
+			name: 'Calling querySelector through a TSNonNullExpression on document',
+			code: 'document!.querySelector( \'.foo\' );\n',
+			errors: [
+				{ messageId: 'documentQuerySelector' }
+			]
+		},
+
+		{
+			name: 'Calling contains through a TSAsExpression cast on ownerDocument',
+			code: '( someEl.ownerDocument as Document ).contains( el );\n',
+			errors: [
+				{ messageId: 'contains' }
 			]
 		}
 	]


### PR DESCRIPTION
### 🚀 Summary

Add `ckeditor5-rules/no-shadow-unsafe-dom-apis` rule.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5-commercial/issues/11097
* Caused by https://github.com/ckeditor/ckeditor5-commercial/issues/10990
* Epic https://github.com/ckeditor/ckeditor5-commercial/issues/10979
* Required by https://github.com/ckeditor/ckeditor5-commercial/pull/11085
