### PR TITLE
Widen the typescript peer dependency range in eslint-config-ckeditor5

### DIFF
--- a/.changelog/20260722130254_ck_4327_ts_peer.md
+++ b/.changelog/20260722130254_ck_4327_ts_peer.md
@@ -5,4 +5,4 @@ scope:
   - eslint-config-ckeditor5
 ---
 
-Widened the `typescript` peer dependency range from the exact `5.5.4` to `^5.0.0`, so the shared configuration can be used in projects on any TypeScript 5.x release (for example Angular projects on TypeScript 5.8) without a peer dependency mismatch. The exact version remains pinned as a dev dependency for building and testing.
+Widened the `typescript` peer dependency range from the exact `5.5.4` to `^5.5.4`, so the shared configuration no longer reports a peer dependency mismatch in projects using a newer TypeScript 5.x release (for example Angular projects on TypeScript 5.8), while keeping `5.5.4` as the minimum supported and tested version. The exact version remains pinned as a dev dependency for building and testing.

--- a/.changelog/20260722130254_ck_4327_ts_peer.md
+++ b/.changelog/20260722130254_ck_4327_ts_peer.md
@@ -1,0 +1,8 @@
+---
+type: Fix
+
+scope:
+  - eslint-config-ckeditor5
+---
+
+Widened the `typescript` peer dependency range from the exact `5.5.4` to `^5.0.0`, so the shared configuration can be used in projects on any TypeScript 5.x release (for example Angular projects on TypeScript 5.8) without a peer dependency mismatch. The exact version remains pinned as a dev dependency for building and testing.

--- a/packages/eslint-config-ckeditor5/package.json
+++ b/packages/eslint-config-ckeditor5/package.json
@@ -43,6 +43,6 @@
   },
   "peerDependencies": {
     "eslint": "^10.0.0",
-    "typescript": "^5.0.0"
+    "typescript": "^5.5.4"
   }
 }

--- a/packages/eslint-config-ckeditor5/package.json
+++ b/packages/eslint-config-ckeditor5/package.json
@@ -43,6 +43,6 @@
   },
   "peerDependencies": {
     "eslint": "^10.0.0",
-    "typescript": "5.5.4"
+    "typescript": "^5.0.0"
   }
 }


### PR DESCRIPTION
Part of https://github.com/ckeditor/ckeditor5-internal/issues/4327.

`eslint-config-ckeditor5` declared its `typescript` **peer dependency** as an exact pin (`5.5.4`). Any consumer on a different TypeScript 5.x release (e.g. `ckeditor5-angular`, which uses `~5.8.0`) therefore hit an "unmet peer dependency" warning, even though the underlying `typescript-eslint` supports `typescript >=4.8.4 <6.1.0`.

### Change
- `peerDependencies.typescript`: `5.5.4` → **`^5.5.4`**
- `devDependencies.typescript` stays pinned at `5.5.4` (the version used to build/test), so our own builds remain deterministic.