### PR TITLE
Add the `allowedImportPatterns` option to the `allow-imports-only-from-main-package-entry-point` rule

### DIFF
--- a/.changelog/20260728124849_ci_4540_move_manual_tests.md
+++ b/.changelog/20260728124849_ci_4540_move_manual_tests.md
@@ -1,0 +1,10 @@
+---
+type: Feature
+scope:
+  - eslint-plugin-ckeditor5-rules
+  - eslint-config-ckeditor5
+---
+
+The `allow-imports-only-from-main-package-entry-point` rule now accepts the `allowedImportPatterns` option: an array of glob patterns matched against the import path. Imports matching any of these patterns are allowed. It defaults to `[ '**/tests/**/_utils*/**' ]`, which preserves the previous behavior of allowing test utility imports.
+
+The shared `eslint-config-ckeditor5` preset now also allows importing utilities from the `manual/` directories of packages.

--- a/packages/eslint-config-ckeditor5/eslint.config.mjs
+++ b/packages/eslint-config-ckeditor5/eslint.config.mjs
@@ -425,7 +425,12 @@ const rulesSourceCode = [
 
 			'ckeditor5-rules/allow-declare-module-only-in-augmentation-file': 'error',
 
-			'ckeditor5-rules/allow-imports-only-from-main-package-entry-point': 'error',
+			'ckeditor5-rules/allow-imports-only-from-main-package-entry-point': [ 'error', {
+				allowedImportPatterns: [
+					'**/tests/**/_utils*/**',
+					'**/manual/**/_utils*/**'
+				]
+			} ],
 
 			'ckeditor5-rules/require-as-const-returns-in-methods': [ 'error', {
 				methodNames: [ 'pluginName' ]

--- a/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-imports-only-from-main-package-entry-point.js
+++ b/packages/eslint-plugin-ckeditor5-rules/lib/rules/allow-imports-only-from-main-package-entry-point.js
@@ -7,11 +7,16 @@
 
 const fs = require( 'node:fs' );
 const { findPackageJSON } = require( 'node:module' );
+const { posix } = require( 'node:path' );
 const { pathToFileURL } = require( 'node:url' );
 const resolveExports = require( 'resolve.exports' ).exports;
 
 const message = 'Importing from "@ckeditor/*" packages is only allowed from the main package entry point.';
 const packageJsonCache = new Map();
+
+const defaultAllowedImportPatterns = [
+	'**/tests/**/_utils*/**'
+];
 
 module.exports = {
 	meta: {
@@ -23,9 +28,24 @@ module.exports = {
 			url: 'https://ckeditor.com/docs/ckeditor5/latest/framework/contributing/code-style.html#importing-from-modules-ckeditor5-rulesallow-imports-only-from-main-package-entry-point'
 		},
 		fixable: 'code',
-		schema: []
+		schema: [
+			{
+				type: 'object',
+				properties: {
+					allowedImportPatterns: {
+						type: 'array',
+						items: {
+							type: 'string'
+						}
+					}
+				},
+				additionalProperties: false
+			}
+		]
 	},
 	create( context ) {
+		const { allowedImportPatterns = defaultAllowedImportPatterns } = context.options[ 0 ] || {};
+
 		return {
 			ImportDeclaration( node ) {
 				if ( node.specifiers.length === 0 ) {
@@ -51,9 +71,8 @@ module.exports = {
 					return;
 				}
 
-				const isTestUtil = path.match( /\/tests\/(.+\/)*_utils/ );
-
-				if ( isTestUtil ) {
+				if ( allowedImportPatterns.some( pattern => posix.matchesGlob( path, pattern ) ) ) {
+					// Ignore imports matching the explicitly allowed glob patterns, e.g. test utils.
 					return;
 				}
 

--- a/packages/eslint-plugin-ckeditor5-rules/tests/rules/allow-imports-only-from-main-package-entry-point.js
+++ b/packages/eslint-plugin-ckeditor5-rules/tests/rules/allow-imports-only-from-main-package-entry-point.js
@@ -65,7 +65,22 @@ ruleTester.run(
 			'import { Helper } from \'@ckeditor/ckeditor5-core/tests/_utils/helper.js\';',
 			'import { Helper } from \'@ckeditor/ckeditor5-core/tests/manual/_utils/helper.js\';',
 			'import { Helper } from \'@ckeditor/ckeditor5-core/tests/feature/_utils/helper.js\';',
-			'import { Helper } from \'@ckeditor/ckeditor5-core/tests/feature/_utils-tests/helper.js\';'
+			'import { Helper } from \'@ckeditor/ckeditor5-core/tests/feature/_utils-tests/helper.js\';',
+			{
+				name: 'Allow importing from paths matching the `allowedImportPatterns` option',
+				code: 'import { Helper } from \'@ckeditor/ckeditor5-core/manual/_utils/helper.js\';',
+				options: [ { allowedImportPatterns: [ '**/manual/**/_utils*/**' ] } ]
+			},
+			{
+				name: 'Allow importing from nested paths matching the `allowedImportPatterns` option',
+				code: 'import { Helper } from \'@ckeditor/ckeditor5-core/manual/feature/_utils/helper.js\';',
+				options: [ { allowedImportPatterns: [ '**/manual/**/_utils*/**' ] } ]
+			},
+			{
+				name: 'Keep allowing test utils when the `allowedImportPatterns` option includes the default pattern',
+				code: 'import { Helper } from \'@ckeditor/ckeditor5-core/tests/_utils/helper.js\';',
+				options: [ { allowedImportPatterns: [ '**/tests/**/_utils*/**', '**/manual/**/_utils*/**' ] } ]
+			}
 		],
 		invalid: [
 			{
@@ -100,6 +115,21 @@ ruleTester.run(
 				code: 'import ExportedFeature from "@ckeditor/ckeditor5-exported-package/dist/feature.js";',
 				output: 'import { ExportedFeature } from \'@ckeditor/ckeditor5-exported-package\';',
 				filename: path.join( fixtureDirectory, 'input.js' ),
+				errors: [ { message } ]
+			},
+			{
+				name: 'Do not allow importing from paths not matching the default `allowedImportPatterns`',
+				code: 'import Helper from "@ckeditor/ckeditor5-no-exports-package/manual/_utils/helper.js";',
+				output: 'import { Helper } from \'@ckeditor/ckeditor5-no-exports-package\';',
+				filename: path.join( fixtureDirectory, 'input.js' ),
+				errors: [ { message } ]
+			},
+			{
+				name: 'Do not allow importing test utils when the `allowedImportPatterns` option is empty',
+				code: 'import Helper from "@ckeditor/ckeditor5-no-exports-package/tests/_utils/helper.js";',
+				output: 'import { Helper } from \'@ckeditor/ckeditor5-no-exports-package\';',
+				filename: path.join( fixtureDirectory, 'input.js' ),
+				options: [ { allowedImportPatterns: [] } ],
 				errors: [ { message } ]
 			}
 		]


### PR DESCRIPTION
### 🚀 Summary

The `allow-imports-only-from-main-package-entry-point` rule hardcoded the paths from which importing package internals is allowed (`tests/**/_utils`). This PR makes it configurable via a new `allowedImportPatterns` option: an array of glob patterns (matched with `path.matchesGlob()`) tested against the import path. The default value preserves the previous behavior.

The shared `eslint-config-ckeditor5` preset now also allows importing utilities from root-level `manual/` directories of packages.

---

### 📌 Related issues

* Closes https://github.com/ckeditor/ckeditor5-internal/issues/4540

---

### 💡 Additional information

None.